### PR TITLE
Improve image collection responsiveness and worker decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ wasm/tiff-decoder/target/
 # Generated bundles
 media/imagePreview.bundle.js
 media/imagePreview.bundle.js.map
+media/decodeWorker.bundle.js
+media/decodeWorker.bundle.js.map

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This is a VS Code extension that provides advanced image visualization for scien
 ### Build & Development
 ```bash
 npm install              # Install dependencies
-npm run compile          # Build using esbuild (creates 3 bundles: Node.js, Web, Webview)
+npm run compile          # Build using esbuild (creates 4 bundles: Node.js, Web, Webview, Decode Worker)
 npm run watch            # Watch mode for development
 npm run vscode:prepublish # Production build
 ```
@@ -45,6 +45,7 @@ The extension uses a sophisticated three-bundle build approach:
 1. **Extension bundle** (`out/extension.js`) - Node.js target for VS Code desktop API integration
 2. **Web bundle** (`out/extension.web.js`) - Browser target for VS Code Web/vscode.dev support
 3. **Webview bundle** (`media/imagePreview.js`) - Browser-based visualization with ES6 modules
+4. **Decode worker bundle** (`media/decode-worker.js` → `media/decodeWorker.bundle.js`) - Web Worker running the pure-data format decoders (TIFF via WASM, EXR, NPY/NPZ, PFM, PPM, 16-bit PNG, HDR) off the webview UI thread. File bytes and decoded typed arrays cross the thread boundary as zero-copy transfers. Booted from a blob URL by [media/modules/decode-worker-client.js](media/modules/decode-worker-client.js); every format keeps its main-thread decoder as an automatic fallback, so an unavailable worker never breaks loading.
 
 This allows the extension to work in both desktop VS Code and browser-based VS Code (vscode.dev).
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -51,6 +51,18 @@ const webviewBuildOptions = {
   format: 'esm',
 };
 
+// Build the decode worker (runs format decoders off the webview UI thread).
+// IIFE so it can boot as a classic worker from a blob URL.
+const decodeWorkerBuildOptions = {
+  entryPoints: ['media/decode-worker.js'],
+  bundle: true,
+  outfile: 'media/decodeWorker.bundle.js',
+  platform: 'browser',
+  target: 'es2020',
+  sourcemap: true,
+  format: 'iife',
+};
+
 // Build tests if they exist
 const testBuildOptions = {
   entryPoints: [],
@@ -131,6 +143,16 @@ if (isWatch) {
       }
     },
   };
+
+  decodeWorkerBuildOptions.watch = {
+    onRebuild(error) {
+      if (error) {
+        console.error('decode worker watch build failed:', error);
+      } else {
+        console.log('decode worker watch build succeeded');
+      }
+    },
+  };
 }
 
 function copyMediaAssets() {
@@ -186,6 +208,10 @@ async function buildAll() {
     // Build webview scripts
     await build(webviewBuildOptions);
     console.log('Webview scripts built successfully');
+
+    // Build decode worker
+    await build(decodeWorkerBuildOptions);
+    console.log('Decode worker built successfully');
 
     // Build tests if they exist
     if (testBuildOptions.entryPoints.length > 0) {

--- a/esbuild.js
+++ b/esbuild.js
@@ -52,7 +52,7 @@ const webviewBuildOptions = {
 };
 
 // Build the decode worker (runs format decoders off the webview UI thread).
-// IIFE so it can boot as a classic worker from a blob URL.
+// ESM preserves import.meta.url used by bundled WASM/worker dependencies.
 const decodeWorkerBuildOptions = {
   entryPoints: ['media/decode-worker.js'],
   bundle: true,
@@ -60,7 +60,7 @@ const decodeWorkerBuildOptions = {
   platform: 'browser',
   target: 'es2020',
   sourcemap: true,
-  format: 'iife',
+  format: 'esm',
 };
 
 // Build tests if they exist
@@ -224,4 +224,4 @@ async function buildAll() {
   }
 }
 
-buildAll(); 
+buildAll();

--- a/media/decode-worker.js
+++ b/media/decode-worker.js
@@ -1,0 +1,186 @@
+// @ts-check
+"use strict";
+
+/**
+ * Decode Web Worker for TIFF Visualizer.
+ *
+ * Runs the CPU-heavy format decoders off the webview UI thread so pixel
+ * decoding never blocks input handling or painting. The main thread sends a
+ * file's bytes with ownership transferred; the worker decodes them and
+ * transfers the decoded typed arrays back — zero copies in either direction.
+ *
+ * Only pure-data decoders live here. Formats whose decode path needs DOM APIs
+ * (8-bit PNG/JPEG and WebP/AVIF/BMP/ICO via the native Image element, TGA,
+ * JXL) or that already decode off-thread (camera RAW via the libraw worker)
+ * keep their existing processors. Every format handled here also keeps its
+ * local decoder as a fallback: on any worker error the input bytes are
+ * transferred back so the caller can decode locally without refetching.
+ */
+
+import './modules/worker-shims.js';
+// Vendored, window-attaching parse-exr build with channel-name support — the
+// npm parse-exr package lacks channelNames/displayedChannels, so the worker
+// must use the exact same build as the main thread.
+import './parse-exr.js';
+import UPNG from './upng.min.js';
+import parseHdr from 'parse-hdr';
+import initTiffWasm, { decode_tiff } from './wasm/tiff-wasm.js';
+import { NpyProcessor } from './modules/npy-processor.js';
+import { PfmProcessor } from './modules/pfm-processor.js';
+import { PpmProcessor } from './modules/ppm-processor.js';
+
+// Parser-only instances: the constructors just assign fields, and the
+// _parse* methods used here touch no DOM or vscode APIs.
+const npyParser = new NpyProcessor(/** @type {any} */ (null), null);
+const pfmParser = new PfmProcessor(/** @type {any} */ (null), null);
+const ppmParser = new PpmProcessor(/** @type {any} */ (null), null);
+
+let tiffWasmReady = false;
+
+/** @param {string[]} urls - Candidate URLs for tiff-wasm.wasm */
+async function initTiffDecoder(urls) {
+	for (const url of urls || []) {
+		try {
+			await initTiffWasm(url);
+			tiffWasmReady = true;
+			return;
+		} catch (error) {
+			console.warn('[DecodeWorker] TIFF WASM init failed for', url, error);
+		}
+	}
+}
+
+/**
+ * Decode a TIFF with the Rust/WASM decoder, mirroring TiffWasmProcessor.decode
+ * and additionally deinterleaving the per-channel rasters off-thread.
+ * @param {ArrayBuffer} buffer
+ */
+function decodeTiff(buffer) {
+	if (!tiffWasmReady) {
+		throw new Error('TIFF WASM decoder not initialized');
+	}
+	const result = decode_tiff(new Uint8Array(buffer));
+	const width = result.width;
+	const height = result.height;
+	const channels = result.channels;
+	const data = new Float32Array(result.get_data_as_f32());
+
+	/** @type {Float32Array[]} */
+	const rasters = [];
+	if (channels === 1) {
+		rasters.push(data);
+	} else {
+		const pixelCount = width * height;
+		for (let c = 0; c < channels; c++) {
+			const channel = new Float32Array(pixelCount);
+			for (let i = 0; i < pixelCount; i++) {
+				channel[i] = data[i * channels + c];
+			}
+			rasters.push(channel);
+		}
+	}
+
+	return {
+		width,
+		height,
+		channels,
+		bitsPerSample: result.bits_per_sample,
+		sampleFormat: result.sample_format,
+		compression: result.compression,
+		predictor: result.predictor,
+		photometricInterpretation: result.photometric_interpretation,
+		planarConfiguration: result.planar_configuration,
+		data,
+		rasters,
+		min: result.min_value,
+		max: result.max_value,
+		decodedWith: 'wasm (worker)',
+	};
+}
+
+/**
+ * @param {string} format
+ * @param {ArrayBuffer} buffer
+ */
+function decodeFormat(format, buffer) {
+	switch (format) {
+		case 'tiff':
+			return decodeTiff(buffer);
+		case 'exr':
+			// FloatType (1015): decoded Float32Array values, matching exr-processor.
+			// @ts-ignore — parseExr is attached to the (shimmed) window by parse-exr.js
+			return globalThis.parseExr(buffer, 1015);
+		case 'npy': {
+			const view = new DataView(buffer);
+			// NPZ (ZIP) signature 0x04034b50
+			if (buffer.byteLength >= 4 && view.getUint32(0, true) === 0x04034b50) {
+				return npyParser._parseNpz(buffer);
+			}
+			return npyParser._parseNpy(buffer);
+		}
+		case 'pfm':
+			return pfmParser._parsePfm(buffer);
+		case 'ppm':
+			return ppmParser._parsePpm(buffer);
+		case 'png16':
+			return UPNG.decode(buffer);
+		case 'hdr':
+			return parseHdr(buffer);
+		default:
+			throw new Error(`Unknown decode format: ${format}`);
+	}
+}
+
+/**
+ * Collect every distinct ArrayBuffer reachable from a decode result so its
+ * typed arrays are transferred (zero-copy) instead of structured-cloned.
+ * @param {any} value
+ * @param {Set<ArrayBuffer>} [buffers]
+ * @param {number} [depth]
+ * @returns {ArrayBuffer[]}
+ */
+function collectTransferables(value, buffers = new Set(), depth = 0) {
+	if (value == null || depth > 4) {
+		return [...buffers];
+	}
+	if (value instanceof ArrayBuffer) {
+		buffers.add(value);
+	} else if (ArrayBuffer.isView(value)) {
+		if (value.buffer instanceof ArrayBuffer) {
+			buffers.add(value.buffer);
+		}
+	} else if (Array.isArray(value)) {
+		for (const item of value) {
+			collectTransferables(item, buffers, depth + 1);
+		}
+	} else if (typeof value === 'object' && value.constructor === Object) {
+		for (const key of Object.keys(value)) {
+			collectTransferables(value[key], buffers, depth + 1);
+		}
+	}
+	return [...buffers];
+}
+
+self.onmessage = async (event) => {
+	const msg = event.data;
+	if (msg.type === 'init') {
+		await initTiffDecoder(msg.tiffWasmUrls);
+		self.postMessage({ type: 'ready', caps: { tiffWasm: tiffWasmReady } });
+		return;
+	}
+
+	const { id, format, buffer } = msg;
+	try {
+		const result = decodeFormat(format, buffer);
+		self.postMessage({ id, ok: true, result }, collectTransferables(result));
+	} catch (error) {
+		// Send the input bytes back (transferred) so the caller can fall back
+		// to its local decoder without refetching the file.
+		const message = String((error instanceof Error ? error.message : error) || 'decode failed');
+		try {
+			self.postMessage({ id, ok: false, error: message, buffer }, [buffer]);
+		} catch {
+			self.postMessage({ id, ok: false, error: message });
+		}
+	}
+};

--- a/media/decode-worker.js
+++ b/media/decode-worker.js
@@ -22,6 +22,10 @@ import './modules/worker-shims.js';
 // npm parse-exr package lacks channelNames/displayedChannels, so the worker
 // must use the exact same build as the main thread.
 import './parse-exr.js';
+// Keep the compatibility TIFF fallback in this worker too. Some valid TIFF
+// variants are not supported by the Rust decoder, and decoding those with
+// geotiff.js on the webview thread would freeze the UI.
+import * as WorkerGeoTIFF from './geotiff.min.js';
 import UPNG from './upng.min.js';
 import parseHdr from 'parse-hdr';
 import initTiffWasm, { decode_tiff } from './wasm/tiff-wasm.js';
@@ -36,12 +40,43 @@ const pfmParser = new PfmProcessor(/** @type {any} */ (null), null);
 const ppmParser = new PpmProcessor(/** @type {any} */ (null), null);
 
 let tiffWasmReady = false;
+/** @type {Promise<void>|null} */
+let tiffWasmInitPromise = null;
+const TIFF_WASM_INIT_TIMEOUT_MS = 3000;
 
-/** @param {string[]} urls - Candidate URLs for tiff-wasm.wasm */
-async function initTiffDecoder(urls) {
+/** @param {Promise<any>} promise @param {number} ms @param {string} message */
+function withTimeout(promise, ms, message) {
+	return Promise.race([
+		promise,
+		new Promise((_, reject) => setTimeout(() => reject(new Error(message)), ms)),
+	]);
+}
+
+/**
+ * @param {ArrayBuffer|null|undefined} buffer - Bytes fetched by the webview
+ * @param {string[]} urls - Candidate URLs for ordinary browser workers
+ */
+async function initTiffDecoder(buffer, urls) {
+	if (buffer?.byteLength) {
+		try {
+			await withTimeout(
+				initTiffWasm({ module_or_path: buffer }),
+				TIFF_WASM_INIT_TIMEOUT_MS,
+				'TIFF WASM byte initialization timed out',
+			);
+			tiffWasmReady = true;
+			return;
+		} catch (error) {
+			console.warn('[DecodeWorker] TIFF WASM byte initialization failed', error);
+		}
+	}
 	for (const url of urls || []) {
 		try {
-			await initTiffWasm(url);
+			await withTimeout(
+				initTiffWasm({ module_or_path: url }),
+				TIFF_WASM_INIT_TIMEOUT_MS,
+				'TIFF WASM URL initialization timed out',
+			);
 			tiffWasmReady = true;
 			return;
 		} catch (error) {
@@ -55,7 +90,7 @@ async function initTiffDecoder(urls) {
  * and additionally deinterleaving the per-channel rasters off-thread.
  * @param {ArrayBuffer} buffer
  */
-function decodeTiff(buffer) {
+function decodeTiffWasm(buffer) {
 	if (!tiffWasmReady) {
 		throw new Error('TIFF WASM decoder not initialized');
 	}
@@ -99,10 +134,81 @@ function decodeTiff(buffer) {
 }
 
 /**
+ * Decode TIFF variants unsupported by the Rust decoder without blocking the
+ * webview thread.
+ * @param {ArrayBuffer} buffer
+ * @param {string} wasmError
+ */
+async function decodeTiffGeotiff(buffer, wasmError) {
+	const tiff = await WorkerGeoTIFF.fromArrayBuffer(buffer);
+	const image = await tiff.getImage();
+	const width = image.getWidth();
+	const height = image.getHeight();
+	const samplesPerPixel = image.getSamplesPerPixel();
+	const rawBitsPerSample = image.getBitsPerSample();
+	const rawSampleFormat = image.getSampleFormat();
+	const bitsPerSample = Array.isArray(rawBitsPerSample) ? rawBitsPerSample[0] : rawBitsPerSample;
+	const sampleFormat = Array.isArray(rawSampleFormat) ? rawSampleFormat[0] : rawSampleFormat;
+	const decodedRasters = await image.readRasters();
+	const fileDirectory = image.fileDirectory || {};
+
+	/** @type {Float32Array} */
+	let data;
+	/** @type {Float32Array[]|any[]} */
+	let rasters;
+	if (samplesPerPixel === 1) {
+		data = new Float32Array(decodedRasters[0]);
+		rasters = [data];
+	} else {
+		const pixelCount = width * height;
+		data = new Float32Array(pixelCount * samplesPerPixel);
+		for (let i = 0; i < pixelCount; i++) {
+			for (let c = 0; c < samplesPerPixel; c++) {
+				data[i * samplesPerPixel + c] = decodedRasters[c][i];
+			}
+		}
+		rasters = decodedRasters;
+	}
+
+	return {
+		width,
+		height,
+		channels: samplesPerPixel,
+		bitsPerSample,
+		sampleFormat,
+		compression: fileDirectory.Compression || 1,
+		predictor: fileDirectory.Predictor || 1,
+		photometricInterpretation: fileDirectory.PhotometricInterpretation || 1,
+		planarConfiguration: fileDirectory.PlanarConfiguration || 1,
+		data,
+		rasters,
+		decodedWith: 'geotiff.js (worker)',
+		wasmFallbackReason: wasmError,
+	};
+}
+
+/** @param {ArrayBuffer} buffer */
+async function decodeTiff(buffer) {
+	if (tiffWasmInitPromise) {
+		// WASM is preferred, but a slow or wedged initialization must never
+		// prevent the worker's GeoTIFF compatibility decoder from running.
+		await withTimeout(tiffWasmInitPromise, TIFF_WASM_INIT_TIMEOUT_MS, 'TIFF WASM init wait timed out')
+			.catch(error => console.warn('[DecodeWorker]', error));
+	}
+	try {
+		return decodeTiffWasm(buffer);
+	} catch (error) {
+		const message = String((error instanceof Error ? error.message : error) || 'WASM decode failed');
+		console.warn('[DecodeWorker] TIFF WASM decode failed, using geotiff.js in worker:', message);
+		return decodeTiffGeotiff(buffer, message);
+	}
+}
+
+/**
  * @param {string} format
  * @param {ArrayBuffer} buffer
  */
-function decodeFormat(format, buffer) {
+async function decodeFormat(format, buffer) {
 	switch (format) {
 		case 'tiff':
 			return decodeTiff(buffer);
@@ -164,14 +270,19 @@ function collectTransferables(value, buffers = new Set(), depth = 0) {
 self.onmessage = async (event) => {
 	const msg = event.data;
 	if (msg.type === 'init') {
-		await initTiffDecoder(msg.tiffWasmUrls);
-		self.postMessage({ type: 'ready', caps: { tiffWasm: tiffWasmReady } });
+		// GeoTIFF is ready as soon as the worker bundle has loaded. Advertise
+		// that immediately so early image loads do not fall back to the UI
+		// thread while WASM is still initializing.
+		self.postMessage({ type: 'ready', caps: { tiff: true, tiffWasm: false } });
+		tiffWasmInitPromise = initTiffDecoder(msg.tiffWasmBuffer, msg.tiffWasmUrls);
+		await tiffWasmInitPromise;
+		self.postMessage({ type: 'caps', caps: { tiff: true, tiffWasm: tiffWasmReady } });
 		return;
 	}
 
 	const { id, format, buffer } = msg;
 	try {
-		const result = decodeFormat(format, buffer);
+		const result = await decodeFormat(format, buffer);
 		self.postMessage({ id, ok: true, result }, collectTransferables(result));
 	} catch (error) {
 		// Send the input bytes back (transferred) so the caller can fall back

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -2402,10 +2402,17 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	 * @param {number} gen
 	 */
 	async function loadImageByType(uri, resourceUri, gen) {
-		// Yield one macrotask so a burst of queued switch messages (rapid key
-		// presses) is fully processed before any decode starts; all but the
-		// newest switch bail out here instead of each running a complete load.
-		await new Promise(resolve => setTimeout(resolve, 0));
+		// Wait until the browser has painted the loading UI (counter, filename
+		// badge, loading dot) before starting synchronous decode work, so every
+		// switch gives immediate visual feedback. This also lets a burst of
+		// queued switch messages (rapid key presses) be processed first — all
+		// but the newest switch bail out here instead of running a full load.
+		// The plain timeout races as a fallback because requestAnimationFrame
+		// does not fire while the webview is hidden.
+		await new Promise(resolve => {
+			requestAnimationFrame(() => setTimeout(resolve, 0));
+			setTimeout(resolve, 100);
+		});
 		if (gen !== _loadGeneration) { return; }
 		const lower = resourceUri.toLowerCase();
 		if (lower.endsWith('.tif') || lower.endsWith('.tiff')) {

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -18,6 +18,7 @@ import { MouseHandler } from './modules/mouse-handler.js';
 import { HistogramOverlay } from './modules/histogram-overlay.js';
 import { ColormapConverter } from './modules/colormap-converter.js';
 import { DecodeWorkerClient } from './modules/decode-worker-client.js';
+import { PerfTrace } from './modules/perf-trace.js';
 
 /**
  * Main Image Preview Application
@@ -375,6 +376,13 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 		});
 	}
 
+	// PerfTrace summaries go to both the webview console and the extension's
+	// Output channel, so timing is visible without opening Developer Tools.
+	PerfTrace.setLogger((message) => {
+		console.log(message);
+		logToOutput(message);
+	});
+
 	/**
 	 * Helper to render ImageData to canvas using createImageBitmap for performance
 	 * @param {ImageData} imageData
@@ -394,6 +402,7 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 		if (pixelCount > 25_000_000) {
 			ctx.putImageData(imageData, 0, 0);
 			console.log(`[Canvas] putImageData upload took ${(performance.now() - start).toFixed(2)}ms`);
+			PerfTrace.mark('canvas-upload');
 			return;
 		}
 		try {
@@ -407,6 +416,7 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 			ctx.putImageData(imageData, 0, 0);
 			console.log(`[Canvas] putImageData fallback took ${(performance.now() - fallbackStart).toFixed(2)}ms`);
 		}
+		PerfTrace.mark('canvas-upload');
 	}
 
 	/**
@@ -454,6 +464,7 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 	 * Handle image loading error, with optional specific message.
 	 */
 	function onImageError(/** @type {string} */ message = '') {
+		PerfTrace.cancel();
 		hasLoadedImage = true;
 		// Remove previous image/canvas so the error message shows on a clean background
 		container.querySelectorAll('img, canvas').forEach(el => {
@@ -893,6 +904,14 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 
 		// Update histogram if visible
 		updateHistogramData();
+
+		// Close the switch trace once the final pixels are shown. With a deferred
+		// render pending this call is the placeholder finalize — keep the trace
+		// open; the post-deferred finalize (pending cleared by then) ends it.
+		PerfTrace.mark('finalize');
+		if (!hasPendingDeferred) {
+			PerfTrace.end();
+		}
 	}
 
 	function swapImageElementToCanvas() {
@@ -993,6 +1012,9 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 
 				// Check if this is a deferred render trigger (initial load)
 				if (message.isInitialRender && canvas) {
+					// Time between formatInfo going out and per-format settings
+					// coming back — extension-host latency, not main-thread work.
+					PerfTrace.mark('await-settings');
 					// Trigger deferred rendering for the appropriate processor
 					let deferredImageData = null;
 					let deferredCanvasAlreadyRendered = false;
@@ -2338,6 +2360,10 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 		// previous rapid press can detect it is stale and bail out.
 		const gen = ++_loadGeneration;
 
+		// Trace where this switch spends its time; the summary is logged from
+		// finalizeImageSetup once the final pixels are on screen.
+		PerfTrace.begin(`switch ${resourceUri.split('/').pop()}`);
+
 		// Abort the previous in-flight load: cancels its network fetch and lets
 		// the processors stop before decoding, instead of the superseded load
 		// running to completion and blocking the next image.
@@ -2421,6 +2447,7 @@ import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 			setTimeout(resolve, 100);
 		});
 		if (gen !== _loadGeneration) { return; }
+		PerfTrace.mark('paint-yield');
 		const lower = resourceUri.toLowerCase();
 		if (lower.endsWith('.tif') || lower.endsWith('.tiff')) {
 			handleTiff(uri, gen);

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -17,6 +17,7 @@ import { ZoomController } from './modules/zoom-controller.js';
 import { MouseHandler } from './modules/mouse-handler.js';
 import { HistogramOverlay } from './modules/histogram-overlay.js';
 import { ColormapConverter } from './modules/colormap-converter.js';
+import { DecodeWorkerClient } from './modules/decode-worker-client.js';
 
 /**
  * Main Image Preview Application
@@ -68,6 +69,12 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	const rawProcessor = new RawProcessor(settingsManager, vscode);
 	// All format processors, for bulk per-switch state resets and load cancellation.
 	const allProcessors = [tiffProcessor, exrProcessor, npyProcessor, pfmProcessor, ppmProcessor, pngProcessor, hdrProcessor, tgaProcessor, webImageProcessor, jxlProcessor, rawProcessor];
+	// Off-thread decode worker, pre-warmed in the background. Processors fall
+	// back to their local (main-thread) decoders until it is ready or if it
+	// is unavailable, so worker failures never break image loading.
+	const decodeWorkerClient = new DecodeWorkerClient();
+	decodeWorkerClient.start();
+	for (const p of allProcessors) { p.decodeWorker = decodeWorkerClient; }
 	const histogramOverlay = new HistogramOverlay(settingsManager, vscode);
 	const colormapConverter = new ColormapConverter();
 	mouseHandler.setNpyProcessor(npyProcessor);

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -75,7 +75,8 @@ import { PerfTrace } from './modules/perf-trace.js';
 	// is unavailable, so worker failures never break image loading.
 	const decodeWorkerClient = new DecodeWorkerClient();
 	decodeWorkerClient.start();
-	for (const p of allProcessors) { p.decodeWorker = decodeWorkerClient; }
+	const workerProcessors = [tiffProcessor, exrProcessor, npyProcessor, pfmProcessor, ppmProcessor, pngProcessor, hdrProcessor];
+	for (const p of workerProcessors) { p.decodeWorker = decodeWorkerClient; }
 	const histogramOverlay = new HistogramOverlay(settingsManager, vscode);
 	const colormapConverter = new ColormapConverter();
 	mouseHandler.setNpyProcessor(npyProcessor);
@@ -119,10 +120,30 @@ import { PerfTrace } from './modules/perf-trace.js';
 	let _loadGeneration = 0;     // Incremented on every switchToNewImage; stale loads bail out
 	/** @type {AbortController|null} */
 	let _loadAbortController = null; // Aborts the in-flight load's fetch when a newer switch supersedes it
+	/** @type {Promise<void>} */
+	let _tiffCanvasReadyPromise;
+	/** @type {(() => void)|null} */
+	let _tiffCanvasReadyResolve = null;
 	let isShowingPeer = false;
 	let initialLoadStartTime = 0;
 	let extensionLoadStartTime = 0; // Time when extension started loading (from settings)
 	let currentLoadFormat = '';
+
+	function resetTiffCanvasReady() {
+		// Release a stale waiter before replacing it; its generation check will
+		// prevent it from rendering into the next image.
+		_tiffCanvasReadyResolve?.();
+		_tiffCanvasReadyPromise = new Promise(resolve => {
+			_tiffCanvasReadyResolve = resolve;
+		});
+	}
+
+	function signalTiffCanvasReady() {
+		_tiffCanvasReadyResolve?.();
+		_tiffCanvasReadyResolve = null;
+	}
+
+	resetTiffCanvasReady();
 
 	// Colormap conversion state
 	/** @type {ColormapConversionState|null} */
@@ -193,6 +214,11 @@ import { PerfTrace } from './modules/perf-trace.js';
 		initialLoadStartTime = performance.now();
 		// Get the extension start time from settings (for total elapsed measurement)
 		extensionLoadStartTime = settingsManager.settings.loadStartTime || 0;
+		// The initial image must be cancellable too. Without a signal, switching
+		// while it decodes lets the stale load continue after its worker is
+		// terminated and interfere with the newest image.
+		_loadAbortController = new AbortController();
+		for (const p of allProcessors) { p.loadSignal = _loadAbortController.signal; }
 		setupImageLoading();
 		setupMessageHandling();
 		setupEventListeners();
@@ -466,6 +492,7 @@ import { PerfTrace } from './modules/perf-trace.js';
 	function onImageError(/** @type {string} */ message = '') {
 		PerfTrace.cancel();
 		hasLoadedImage = true;
+		signalTiffCanvasReady();
 		// Remove previous image/canvas so the error message shows on a clean background
 		container.querySelectorAll('img, canvas').forEach(el => {
 			if (!el.closest('.histogram-overlay')) {
@@ -502,6 +529,7 @@ import { PerfTrace } from './modules/perf-trace.js';
 			}
 
 			hasLoadedImage = true;
+			signalTiffCanvasReady();
 			if (!tiffProcessor._pendingRenderData) {
 				finalizeImageSetup();
 				const endTime = performance.now();
@@ -1009,6 +1037,17 @@ import { PerfTrace } from './modules/perf-trace.js';
 				const oldResourceUri = settingsManager.settings.resourceUri;
 				const changes = settingsManager.updateSettings(message.settings);
 				const newResourceUri = settingsManager.settings.resourceUri;
+
+				// formatInfo is posted from inside processTiff(), before handleTiff()
+				// receives and installs its canvas. Do not drop the immediate
+				// initial-settings response while that canvas is still in flight.
+				if (message.isInitialRender && currentLoadFormat === 'TIFF' && !canvas) {
+					const waitingGeneration = _loadGeneration;
+					await _tiffCanvasReadyPromise;
+					if (waitingGeneration !== _loadGeneration) {
+						break;
+					}
+				}
 
 				// Check if this is a deferred render trigger (initial load)
 				if (message.isInitialRender && canvas) {
@@ -2368,6 +2407,8 @@ import { PerfTrace } from './modules/perf-trace.js';
 		// the processors stop before decoding, instead of the superseded load
 		// running to completion and blocking the next image.
 		if (_loadAbortController) { _loadAbortController.abort(); }
+		decodeWorkerClient.cancelActiveDecodes();
+		resetTiffCanvasReady();
 		_loadAbortController = new AbortController();
 		for (const p of allProcessors) { p.loadSignal = _loadAbortController.signal; }
 
@@ -2411,7 +2452,8 @@ import { PerfTrace } from './modules/perf-trace.js';
 		tiffProcessor._convertedFloatData = null;
 		exrProcessor.rawExrData = undefined;
 		exrProcessor._cachedStats = undefined;
-		for (const p of allProcessors) { p._lastRaw = null; }
+		const rawDataProcessors = [exrProcessor, npyProcessor, pfmProcessor, ppmProcessor, pngProcessor, hdrProcessor, tgaProcessor, webImageProcessor, jxlProcessor, rawProcessor];
+		for (const p of rawDataProcessors) { p._lastRaw = null; }
 		rawProcessor._arrayBuffer = null;
 
 		// Drop any pending deferred-render data from the previous image. Otherwise a

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -66,6 +66,8 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	const webImageProcessor = new WebImageProcessor(settingsManager, vscode);
 	const jxlProcessor = new JxlProcessor(settingsManager, vscode);
 	const rawProcessor = new RawProcessor(settingsManager, vscode);
+	// All format processors, for bulk per-switch state resets and load cancellation.
+	const allProcessors = [tiffProcessor, exrProcessor, npyProcessor, pfmProcessor, ppmProcessor, pngProcessor, hdrProcessor, tgaProcessor, webImageProcessor, jxlProcessor, rawProcessor];
 	const histogramOverlay = new HistogramOverlay(settingsManager, vscode);
 	const colormapConverter = new ColormapConverter();
 	mouseHandler.setNpyProcessor(npyProcessor);
@@ -107,6 +109,8 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	/** @type {{scale: number|string, [key: string]: any}|null} */
 	let _pendingZoomState = null; // Zoom state to restore after next image load
 	let _loadGeneration = 0;     // Incremented on every switchToNewImage; stale loads bail out
+	/** @type {AbortController|null} */
+	let _loadAbortController = null; // Aborts the in-flight load's fetch when a newer switch supersedes it
 	let isShowingPeer = false;
 	let initialLoadStartTime = 0;
 	let extensionLoadStartTime = 0; // Time when extension started loading (from settings)
@@ -490,6 +494,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling TIFF:', error);
 			const msg = String(error instanceof Error ? error.message : error);
 			if (msg.includes('50000') || msg.toLowerCase().includes('zstd')) {
@@ -534,6 +539,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling EXR:', error);
 			onImageError();
 		}
@@ -566,6 +572,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			}
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling PFM:', error);
 			onImageError();
 		}
@@ -598,6 +605,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			}
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling PPM/PGM:', error);
 			onImageError();
 		}
@@ -630,6 +638,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			}
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling PNG/JPEG:', error);
 			onImageError();
 		}
@@ -662,6 +671,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 			}
 			// else: finalizeImageSetup called after deferred render in updateSettings handler
 		} catch (error) {
+			if (gen !== _loadGeneration) { return; }
 			console.error('Error handling NPY/NPZ:', error);
 			onImageError();
 		}
@@ -2321,6 +2331,13 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 		// previous rapid press can detect it is stale and bail out.
 		const gen = ++_loadGeneration;
 
+		// Abort the previous in-flight load: cancels its network fetch and lets
+		// the processors stop before decoding, instead of the superseded load
+		// running to completion and blocking the next image.
+		if (_loadAbortController) { _loadAbortController.abort(); }
+		_loadAbortController = new AbortController();
+		for (const p of allProcessors) { p.loadSignal = _loadAbortController.signal; }
+
 		// Update the settings with the new resource URI
 		settingsManager.settings.resourceUri = resourceUri;
 		settingsManager.settings.src = uri;
@@ -2350,17 +2367,7 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 		// new image (e.g. switching from TIFF-int to EXR-float needs different
 		// normalization defaults). The AppStateManager caches settings per-format
 		// so any user adjustments are preserved when switching back.
-		tiffProcessor._isInitialLoad = true;
-		exrProcessor._isInitialLoad = true;
-		npyProcessor._isInitialLoad = true;
-		pfmProcessor._isInitialLoad = true;
-		ppmProcessor._isInitialLoad = true;
-		pngProcessor._isInitialLoad = true;
-		hdrProcessor._isInitialLoad = true;
-		tgaProcessor._isInitialLoad = true;
-		webImageProcessor._isInitialLoad = true;
-		jxlProcessor._isInitialLoad = true;
-		rawProcessor._isInitialLoad = true;
+		for (const p of allProcessors) { p._isInitialLoad = true; }
 
 		// Clear each processor's stale raw data so the mouse handler and histogram
 		// don't read pixels from the previous image. Without this, the TIFF-first
@@ -2371,32 +2378,14 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 		tiffProcessor._convertedFloatData = null;
 		exrProcessor.rawExrData = undefined;
 		exrProcessor._cachedStats = undefined;
-		npyProcessor._lastRaw = null;
-		pfmProcessor._lastRaw = null;
-		ppmProcessor._lastRaw = null;
-		pngProcessor._lastRaw = null;
-		hdrProcessor._lastRaw = null;
-		tgaProcessor._lastRaw = null;
-		webImageProcessor._lastRaw = null;
-		jxlProcessor._lastRaw = null;
-		rawProcessor._lastRaw = null;
+		for (const p of allProcessors) { p._lastRaw = null; }
 		rawProcessor._arrayBuffer = null;
 
 		// Drop any pending deferred-render data from the previous image. Otherwise a
 		// late updateSettings(isInitialRender) for the old image could draw it onto
 		// the new image's canvas, overlaying two images of different sizes.
-		tiffProcessor._pendingRenderData = null;
-		exrProcessor._pendingRenderData = null;
-		npyProcessor._pendingRenderData = null;
-		pfmProcessor._pendingRenderData = null;
-		ppmProcessor._pendingRenderData = null;
-		pngProcessor._pendingRenderData = null;
+		for (const p of allProcessors) { p._pendingRenderData = null; }
 		pngProcessor._lazyNativeReadback = null;
-		hdrProcessor._pendingRenderData = null;
-		tgaProcessor._pendingRenderData = null;
-		webImageProcessor._pendingRenderData = null;
-		jxlProcessor._pendingRenderData = null;
-		rawProcessor._pendingRenderData = null;
 
 		// Keep existing image/canvas visible while the new image loads to avoid
 		// a black flash. They will be removed in finalizeImageSetup once the new
@@ -2412,7 +2401,12 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	 * @param {string} resourceUri
 	 * @param {number} gen
 	 */
-	function loadImageByType(uri, resourceUri, gen) {
+	async function loadImageByType(uri, resourceUri, gen) {
+		// Yield one macrotask so a burst of queued switch messages (rapid key
+		// presses) is fully processed before any decode starts; all but the
+		// newest switch bail out here instead of each running a complete load.
+		await new Promise(resolve => setTimeout(resolve, 0));
+		if (gen !== _loadGeneration) { return; }
 		const lower = resourceUri.toLowerCase();
 		if (lower.endsWith('.tif') || lower.endsWith('.tiff')) {
 			handleTiff(uri, gen);

--- a/media/imagePreview.js
+++ b/media/imagePreview.js
@@ -371,6 +371,13 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 	 */
 	async function renderImageDataToCanvas(imageData, ctx) {
 		if (!ctx) return;
+		// Ensure the canvas matches the image size. Without this, drawing a smaller
+		// image onto a canvas still sized for a previous (larger) image leaves the
+		// old pixels visible around the new one — both images appear overlaid.
+		if (ctx.canvas.width !== imageData.width || ctx.canvas.height !== imageData.height) {
+			ctx.canvas.width = imageData.width;
+			ctx.canvas.height = imageData.height;
+		}
 		const start = performance.now();
 		const pixelCount = imageData.width * imageData.height;
 		if (pixelCount > 25_000_000) {
@@ -2374,6 +2381,22 @@ import { ColormapConverter } from './modules/colormap-converter.js';
 		jxlProcessor._lastRaw = null;
 		rawProcessor._lastRaw = null;
 		rawProcessor._arrayBuffer = null;
+
+		// Drop any pending deferred-render data from the previous image. Otherwise a
+		// late updateSettings(isInitialRender) for the old image could draw it onto
+		// the new image's canvas, overlaying two images of different sizes.
+		tiffProcessor._pendingRenderData = null;
+		exrProcessor._pendingRenderData = null;
+		npyProcessor._pendingRenderData = null;
+		pfmProcessor._pendingRenderData = null;
+		ppmProcessor._pendingRenderData = null;
+		pngProcessor._pendingRenderData = null;
+		pngProcessor._lazyNativeReadback = null;
+		hdrProcessor._pendingRenderData = null;
+		tgaProcessor._pendingRenderData = null;
+		webImageProcessor._pendingRenderData = null;
+		jxlProcessor._pendingRenderData = null;
+		rawProcessor._pendingRenderData = null;
 
 		// Keep existing image/canvas visible while the new image loads to avoid
 		// a black flash. They will be removed in finalizeImageSetup once the new

--- a/media/modules/decode-worker-client.js
+++ b/media/modules/decode-worker-client.js
@@ -13,6 +13,8 @@
  * behavior and performance are then identical to not having a worker at all.
  */
 
+import { PerfTrace } from './perf-trace.js';
+
 const DECODE_TIMEOUT_MS = 30000;
 
 export class DecodeWorkerClient {
@@ -183,6 +185,8 @@ export class DecodeWorkerClient {
 			throw new DOMException('Load superseded', 'AbortError');
 		}
 		if (response?.ok) {
+			// Spans the caller's fetch too (it runs just before this helper).
+			PerfTrace.mark(`fetch+decode-worker(${format})`);
 			return response.result;
 		}
 		if (response) {
@@ -193,6 +197,8 @@ export class DecodeWorkerClient {
 			const refetched = await fetch(src, { signal });
 			localBuffer = await refetched.arrayBuffer();
 		}
-		return parseLocal(localBuffer);
+		const result = await parseLocal(localBuffer);
+		PerfTrace.mark(`fetch+decode-local(${format})`);
+		return result;
 	}
 }

--- a/media/modules/decode-worker-client.js
+++ b/media/modules/decode-worker-client.js
@@ -16,13 +16,37 @@
 import { PerfTrace } from './perf-trace.js';
 
 const DECODE_TIMEOUT_MS = 30000;
+const WASM_FETCH_TIMEOUT_MS = 3000;
+
+/**
+ * Fetch the first available resource without allowing a broken webview URI to
+ * hold worker startup indefinitely.
+ * @param {string[]} urls
+ * @returns {Promise<ArrayBuffer|null>}
+ */
+async function fetchFirstArrayBuffer(urls) {
+	for (const url of urls) {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), WASM_FETCH_TIMEOUT_MS);
+		try {
+			const response = await fetch(url, { signal: controller.signal });
+			if (response.ok) {
+				return await response.arrayBuffer();
+			}
+		} catch { /* try next candidate */ }
+		finally {
+			clearTimeout(timer);
+		}
+	}
+	return null;
+}
 
 export class DecodeWorkerClient {
 	constructor() {
 		/** @type {Worker|null} */
 		this._worker = null;
 		this._ready = false;
-		/** @type {{tiffWasm?: boolean}} */
+		/** @type {{tiff?: boolean, tiffWasm?: boolean}} */
 		this._caps = {};
 		/** @type {Map<number, (response: any) => void>} */
 		this._pending = new Map();
@@ -31,6 +55,12 @@ export class DecodeWorkerClient {
 		this._startPromise = null;
 		/** @type {((caps: any) => void)|undefined} */
 		this._readyResolve = undefined;
+		/** @type {string|null} */
+		this._blobUrl = null;
+		/** @type {ArrayBuffer|null} */
+		this._tiffWasmBytes = null;
+		/** @type {Promise<ArrayBuffer|null>|null} */
+		this._tiffWasmFetchPromise = null;
 	}
 
 	/** Begin booting the worker in the background. Never throws. */
@@ -49,6 +79,20 @@ export class DecodeWorkerClient {
 			new URL('./decodeWorker.bundle.js', import.meta.url).href,
 			new URL('../decodeWorker.bundle.js', import.meta.url).href,
 		];
+		const tiffWasmUrls = [
+			new URL('./wasm/tiff-wasm.wasm', import.meta.url).href,
+			new URL('../wasm/tiff-wasm.wasm', import.meta.url).href,
+		];
+		if (!this._tiffWasmBytes && !this._tiffWasmFetchPromise) {
+			this._tiffWasmFetchPromise = fetchFirstArrayBuffer(tiffWasmUrls)
+				.then(bytes => {
+					this._tiffWasmBytes = bytes;
+					return bytes;
+				})
+				.finally(() => {
+					this._tiffWasmFetchPromise = null;
+				});
+		}
 		let source = null;
 		for (const url of candidates) {
 			try {
@@ -64,31 +108,35 @@ export class DecodeWorkerClient {
 		}
 
 		const blobUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
-		const worker = new Worker(blobUrl);
+		this._blobUrl = blobUrl;
+		const worker = new Worker(blobUrl, { type: 'module' });
 		this._worker = worker;
 		worker.onmessage = (event) => this._onMessage(event.data);
 		worker.onerror = (event) => {
+			if (this._worker !== worker) {
+				return;
+			}
 			console.warn('[DecodeWorker] Worker error:', event.message || event);
 			this._teardown();
 		};
 
-		// The worker fetches its own WASM; pass candidate URLs since the
-		// blob worker can't resolve paths relative to the bundle location.
-		const tiffWasmUrls = [
-			new URL('./wasm/tiff-wasm.wasm', import.meta.url).href,
-			new URL('../wasm/tiff-wasm.wasm', import.meta.url).href,
-		];
+		// VS Code webview-resource URLs are authorized in the webview, but a
+		// blob worker may be unable to fetch them. Fetch the WASM here and
+		// transfer a copy into the worker; retain URLs as a browser fallback.
+		const cachedWasmBytes = this._tiffWasmBytes || await this._tiffWasmFetchPromise;
+		const tiffWasmBuffer = cachedWasmBytes?.slice(0) || null;
 		const caps = await new Promise((resolve, reject) => {
 			this._readyResolve = resolve;
 			setTimeout(() => reject(new Error('worker init timeout')), 20000);
-			worker.postMessage({ type: 'init', tiffWasmUrls });
+			const initMessage = { type: 'init', tiffWasmBuffer, tiffWasmUrls };
+			worker.postMessage(initMessage, tiffWasmBuffer ? [tiffWasmBuffer] : []);
 		});
 		if (this._worker !== worker) {
 			return; // torn down while initializing
 		}
 		this._caps = caps || {};
 		this._ready = true;
-		console.log(`[DecodeWorker] Ready (tiffWasm=${!!this._caps.tiffWasm})`);
+		console.log(`[DecodeWorker] Ready (tiff=${!!this._caps.tiff}, tiffWasm=${!!this._caps.tiffWasm})`);
 	}
 
 	/** @param {string} format */
@@ -96,10 +144,10 @@ export class DecodeWorkerClient {
 		if (!this._ready || !this._worker) {
 			return false;
 		}
-		// TIFF is only routed to the worker when its WASM decoder initialized;
-		// otherwise the main thread's WASM path stays the fastest option.
+		// TIFF is routed to the worker whenever either its WASM decoder or its
+		// geotiff.js compatibility fallback is available.
 		if (format === 'tiff') {
-			return !!this._caps.tiffWasm;
+			return !!this._caps.tiff;
 		}
 		return true;
 	}
@@ -147,11 +195,29 @@ export class DecodeWorkerClient {
 			this._readyResolve?.(msg.caps);
 			return;
 		}
+		if (msg && msg.type === 'caps') {
+			this._caps = { ...this._caps, ...msg.caps };
+			console.log(`[DecodeWorker] Capabilities updated (tiff=${!!this._caps.tiff}, tiffWasm=${!!this._caps.tiffWasm})`);
+			return;
+		}
 		const resolve = this._pending.get(msg?.id);
 		if (resolve) {
 			this._pending.delete(msg.id);
 			resolve(msg);
 		}
+	}
+
+	/**
+	 * Stop CPU work for superseded image loads. Web Workers cannot interrupt a
+	 * synchronous decoder, so terminating the worker is the only reliable
+	 * cancellation mechanism. It is restarted lazily by the newest load.
+	 */
+	cancelActiveDecodes() {
+		if (this._pending.size === 0) {
+			return;
+		}
+		console.log(`[DecodeWorker] Cancelling ${this._pending.size} superseded decode(s)`);
+		this._teardown();
 	}
 
 	_teardown() {
@@ -165,6 +231,13 @@ export class DecodeWorkerClient {
 			resolve({ ok: false, error: 'decode worker unavailable' });
 		}
 		this._pending.clear();
+		if (this._blobUrl) {
+			URL.revokeObjectURL(this._blobUrl);
+			this._blobUrl = null;
+		}
+		this._caps = {};
+		this._readyResolve = undefined;
+		this._startPromise = null;
 	}
 
 	/**

--- a/media/modules/decode-worker-client.js
+++ b/media/modules/decode-worker-client.js
@@ -1,0 +1,198 @@
+// @ts-check
+"use strict";
+
+/**
+ * Main-thread client for the decode Web Worker (media/decode-worker.js).
+ *
+ * Boots the worker from a blob URL (VS Code webviews block creating workers
+ * directly from webview URIs — same bootstrap the RAW processor uses) and
+ * exchanges file bytes / decoded results via zero-copy transfers.
+ *
+ * Resilient by design: if the worker can't be created, isn't ready yet,
+ * crashes, or a decode fails, callers fall back to their local decoder —
+ * behavior and performance are then identical to not having a worker at all.
+ */
+
+const DECODE_TIMEOUT_MS = 30000;
+
+export class DecodeWorkerClient {
+	constructor() {
+		/** @type {Worker|null} */
+		this._worker = null;
+		this._ready = false;
+		/** @type {{tiffWasm?: boolean}} */
+		this._caps = {};
+		/** @type {Map<number, (response: any) => void>} */
+		this._pending = new Map();
+		this._nextId = 1;
+		/** @type {Promise<void>|null} */
+		this._startPromise = null;
+		/** @type {((caps: any) => void)|undefined} */
+		this._readyResolve = undefined;
+	}
+
+	/** Begin booting the worker in the background. Never throws. */
+	start() {
+		if (!this._startPromise) {
+			this._startPromise = this._boot().catch(error => {
+				console.warn('[DecodeWorker] Unavailable, decoding stays on the main thread:', error);
+				this._teardown();
+			});
+		}
+		return this._startPromise;
+	}
+
+	async _boot() {
+		const candidates = [
+			new URL('./decodeWorker.bundle.js', import.meta.url).href,
+			new URL('../decodeWorker.bundle.js', import.meta.url).href,
+		];
+		let source = null;
+		for (const url of candidates) {
+			try {
+				const response = await fetch(url);
+				if (response.ok) {
+					source = await response.text();
+					break;
+				}
+			} catch { /* try next candidate */ }
+		}
+		if (!source) {
+			throw new Error('decodeWorker.bundle.js not found');
+		}
+
+		const blobUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
+		const worker = new Worker(blobUrl);
+		this._worker = worker;
+		worker.onmessage = (event) => this._onMessage(event.data);
+		worker.onerror = (event) => {
+			console.warn('[DecodeWorker] Worker error:', event.message || event);
+			this._teardown();
+		};
+
+		// The worker fetches its own WASM; pass candidate URLs since the
+		// blob worker can't resolve paths relative to the bundle location.
+		const tiffWasmUrls = [
+			new URL('./wasm/tiff-wasm.wasm', import.meta.url).href,
+			new URL('../wasm/tiff-wasm.wasm', import.meta.url).href,
+		];
+		const caps = await new Promise((resolve, reject) => {
+			this._readyResolve = resolve;
+			setTimeout(() => reject(new Error('worker init timeout')), 20000);
+			worker.postMessage({ type: 'init', tiffWasmUrls });
+		});
+		if (this._worker !== worker) {
+			return; // torn down while initializing
+		}
+		this._caps = caps || {};
+		this._ready = true;
+		console.log(`[DecodeWorker] Ready (tiffWasm=${!!this._caps.tiffWasm})`);
+	}
+
+	/** @param {string} format */
+	canDecode(format) {
+		if (!this._ready || !this._worker) {
+			return false;
+		}
+		// TIFF is only routed to the worker when its WASM decoder initialized;
+		// otherwise the main thread's WASM path stays the fastest option.
+		if (format === 'tiff') {
+			return !!this._caps.tiffWasm;
+		}
+		return true;
+	}
+
+	/**
+	 * Decode off-thread. Ownership of `buffer` is transferred to the worker.
+	 * Resolves to {ok:true, result} on success or {ok:false, error, buffer?}
+	 * on failure (with the input bytes transferred back when possible).
+	 * Returns null — synchronously, with `buffer` untouched — when the worker
+	 * can't handle this format or isn't available.
+	 * @param {string} format
+	 * @param {ArrayBuffer} buffer
+	 * @returns {Promise<any>|null}
+	 */
+	decode(format, buffer) {
+		if (!this.canDecode(format)) {
+			return null;
+		}
+		const worker = /** @type {Worker} */ (this._worker);
+		const id = this._nextId++;
+		return new Promise(resolve => {
+			const timer = setTimeout(() => {
+				// A hung decode (e.g. a WASM panic loop) must not wedge image
+				// loading; kill the worker and let callers decode locally.
+				console.warn('[DecodeWorker] Decode timed out, terminating worker');
+				this._teardown();
+			}, DECODE_TIMEOUT_MS);
+			this._pending.set(id, (response) => {
+				clearTimeout(timer);
+				resolve(response);
+			});
+			try {
+				worker.postMessage({ id, format, buffer }, [buffer]);
+			} catch (error) {
+				clearTimeout(timer);
+				this._pending.delete(id);
+				resolve({ ok: false, error: String(error), buffer });
+			}
+		});
+	}
+
+	/** @param {any} msg */
+	_onMessage(msg) {
+		if (msg && msg.type === 'ready') {
+			this._readyResolve?.(msg.caps);
+			return;
+		}
+		const resolve = this._pending.get(msg?.id);
+		if (resolve) {
+			this._pending.delete(msg.id);
+			resolve(msg);
+		}
+	}
+
+	_teardown() {
+		this._ready = false;
+		const worker = this._worker;
+		this._worker = null;
+		try {
+			worker?.terminate();
+		} catch { /* already gone */ }
+		for (const resolve of this._pending.values()) {
+			resolve({ ok: false, error: 'decode worker unavailable' });
+		}
+		this._pending.clear();
+	}
+
+	/**
+	 * Decode `buffer` via the worker when possible, falling back to
+	 * `parseLocal` on the main thread. The buffer may have been transferred
+	 * to a failed worker decode; if it can't be recovered, the file is
+	 * refetched (rare error path only).
+	 * @param {DecodeWorkerClient|null|undefined} client
+	 * @param {string} format
+	 * @param {ArrayBuffer} buffer
+	 * @param {string} src
+	 * @param {AbortSignal|undefined} signal
+	 * @param {(buffer: ArrayBuffer) => any} parseLocal
+	 */
+	static async decodeWithFallback(client, format, buffer, src, signal, parseLocal) {
+		const response = client ? await client.decode(format, buffer) : null;
+		if (signal?.aborted) {
+			throw new DOMException('Load superseded', 'AbortError');
+		}
+		if (response?.ok) {
+			return response.result;
+		}
+		if (response) {
+			console.warn(`[DecodeWorker] ${format} worker decode failed, decoding locally:`, response.error);
+		}
+		let localBuffer = response ? response.buffer : buffer;
+		if (!localBuffer || localBuffer.byteLength === 0) {
+			const refetched = await fetch(src, { signal });
+			localBuffer = await refetched.arrayBuffer();
+		}
+		return parseLocal(localBuffer);
+	}
+}

--- a/media/modules/exr-processor.js
+++ b/media/modules/exr-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 
 /** @typedef {import('./settings-manager.js').ImageSettings} ImageSettings */
 /** @typedef {import('./settings-manager.js').SettingsManager} SettingsManager */
@@ -35,6 +36,8 @@ export class ExrProcessor {
 		this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
 		/** @type {AbortSignal|undefined} */
 		this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+		/** @type {DecodeWorkerClient|null} */
+		this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
 	}
 
 	/**
@@ -83,13 +86,15 @@ export class ExrProcessor {
 			// Invalidate stats cache for new image
 			this._cachedStats = undefined;
 
-			// Parse EXR using parse-exr library
+			// Parse EXR using parse-exr library — in the decode worker when
+			// available (same vendored build), locally otherwise.
 			// Use FloatType (1015) to get Float32Array with decoded float values
 			// HalfFloatType (1016) returns Uint16Array with raw bytes which need decoding
-			// @ts-ignore
 			const FloatType = 1015;
-			// @ts-ignore
-			const exrResult = parseExr(buffer, FloatType);
+			const exrResult = await DecodeWorkerClient.decodeWithFallback(
+				this.decodeWorker, 'exr', buffer, src, this.loadSignal,
+				// @ts-ignore
+				(b) => parseExr(b, FloatType));
 
 			const { width, height, data, format, type, channelNames, displayedChannels } = exrResult;
 

--- a/media/modules/exr-processor.js
+++ b/media/modules/exr-processor.js
@@ -33,6 +33,8 @@ export class ExrProcessor {
 		this._pendingRenderData = null; // Store data waiting for format-specific settings
 		this._isInitialLoad = true; // Track if this is the first render
 		this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
+		/** @type {AbortSignal|undefined} */
+		this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
 	}
 
 	/**
@@ -74,8 +76,9 @@ export class ExrProcessor {
 				throw new Error('parseExr library not loaded. Make sure parse-exr is included.');
 			}
 
-			const response = await fetch(src);
+			const response = await fetch(src, { signal: this.loadSignal });
 			const buffer = await response.arrayBuffer();
+			if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
 			// Invalidate stats cache for new image
 			this._cachedStats = undefined;

--- a/media/modules/exr-processor.js
+++ b/media/modules/exr-processor.js
@@ -72,6 +72,7 @@ export class ExrProcessor {
 	 * @returns {Promise<{canvas: HTMLCanvasElement, imageData: ImageData, exrData: Object}>}
 	 */
 	async processExr(src) {
+		const loadSignal = this.loadSignal;
 		try {
 			// Check if parseExr is available (from parse-exr library)
 			// @ts-ignore
@@ -79,9 +80,9 @@ export class ExrProcessor {
 				throw new Error('parseExr library not loaded. Make sure parse-exr is included.');
 			}
 
-			const response = await fetch(src, { signal: this.loadSignal });
+			const response = await fetch(src, { signal: loadSignal });
 			const buffer = await response.arrayBuffer();
-			if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+			if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
 			// Invalidate stats cache for new image
 			this._cachedStats = undefined;
@@ -92,7 +93,7 @@ export class ExrProcessor {
 			// HalfFloatType (1016) returns Uint16Array with raw bytes which need decoding
 			const FloatType = 1015;
 			const exrResult = await DecodeWorkerClient.decodeWithFallback(
-				this.decodeWorker, 'exr', buffer, src, this.loadSignal,
+				this.decodeWorker, 'exr', buffer, src, loadSignal,
 				// @ts-ignore
 				(b) => parseExr(b, FloatType));
 

--- a/media/modules/hdr-processor.js
+++ b/media/modules/hdr-processor.js
@@ -38,15 +38,16 @@ export class HdrProcessor {
 
     /** @param {string} src */
     async processHdr(src) {
-        const response = await fetch(src, { signal: this.loadSignal });
+        const loadSignal = this.loadSignal;
+        const response = await fetch(src, { signal: loadSignal });
         const buffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         // parse-hdr returns { shape:[width,height], exposure, gamma, data:Float32Array }
         // data is RGBA stride-4, alpha is always 1.0
         // Parsed in the decode worker when available, locally otherwise.
         const parsed = await DecodeWorkerClient.decodeWithFallback(
-            this.decodeWorker, 'hdr', buffer, src, this.loadSignal, (b) => parseHdr(b));
+            this.decodeWorker, 'hdr', buffer, src, loadSignal, (b) => parseHdr(b));
         const width = parsed.shape[0];
         const height = parsed.shape[1];
 

--- a/media/modules/hdr-processor.js
+++ b/media/modules/hdr-processor.js
@@ -29,12 +29,15 @@ export class HdrProcessor {
         this._isInitialLoad = true;
         /** @type {{min:number,max:number}|undefined} */
         this._cachedStats = undefined;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /** @param {string} src */
     async processHdr(src) {
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         // parse-hdr returns { shape:[width,height], exposure, gamma, data:Float32Array }
         // data is RGBA stride-4, alpha is always 1.0

--- a/media/modules/hdr-processor.js
+++ b/media/modules/hdr-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 import parseHdr from 'parse-hdr';
 
 /** @typedef {import('./settings-manager.js').SettingsManager} SettingsManager */
@@ -31,6 +32,8 @@ export class HdrProcessor {
         this._cachedStats = undefined;
         /** @type {AbortSignal|undefined} */
         this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+        /** @type {DecodeWorkerClient|null} */
+        this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
     }
 
     /** @param {string} src */
@@ -41,7 +44,9 @@ export class HdrProcessor {
 
         // parse-hdr returns { shape:[width,height], exposure, gamma, data:Float32Array }
         // data is RGBA stride-4, alpha is always 1.0
-        const parsed = parseHdr(buffer);
+        // Parsed in the decode worker when available, locally otherwise.
+        const parsed = await DecodeWorkerClient.decodeWithFallback(
+            this.decodeWorker, 'hdr', buffer, src, this.loadSignal, (b) => parseHdr(b));
         const width = parsed.shape[0];
         const height = parsed.shape[1];
 

--- a/media/modules/jxl-processor.js
+++ b/media/modules/jxl-processor.js
@@ -67,16 +67,18 @@ export class JxlProcessor {
      * @param {string} src
      */
     async processJxl(src) {
+        const loadSignal = this.loadSignal;
         this._cachedStats = undefined;
         await this.ensureWasmLoaded();
 
-        const response = await fetch(src, { signal: this.loadSignal });
+        const response = await fetch(src, { signal: loadSignal });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const arrayBuffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         // @jsquash/jxl decode returns a standard ImageData (RGBA, 8-bit)
         const decoded = await decode(arrayBuffer);
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         const width = decoded.width;
         const height = decoded.height;

--- a/media/modules/jxl-processor.js
+++ b/media/modules/jxl-processor.js
@@ -28,6 +28,8 @@ export class JxlProcessor {
         /** @type {{min:number,max:number}|undefined} */
         this._cachedStats = undefined;
         this._isWasmLoaded = false;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     async ensureWasmLoaded() {
@@ -68,9 +70,10 @@ export class JxlProcessor {
         this._cachedStats = undefined;
         await this.ensureWasmLoaded();
 
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const arrayBuffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         // @jsquash/jxl decode returns a standard ImageData (RGBA, 8-bit)
         const decoded = await decode(arrayBuffer);

--- a/media/modules/normalization-helper.js
+++ b/media/modules/normalization-helper.js
@@ -1,6 +1,8 @@
 // @ts-check
 "use strict";
 
+import { PerfTrace } from './perf-trace.js';
+
 /** @typedef {import('./settings-manager.js').ImageSettings} ImageSettings */
 
 /**
@@ -219,6 +221,7 @@ export class ImageStatsCalculator {
         }
 
         console.log(`[Stats] Float stats calculation took ${(performance.now() - perfStart).toFixed(2)}ms`);
+        PerfTrace.mark('stats');
         return { min: minVal, max: maxVal };
     }
 
@@ -252,6 +255,7 @@ export class ImageStatsCalculator {
             }
         }
 
+        PerfTrace.mark('stats');
         return { min: minVal, max: maxVal };
     }
 }
@@ -280,9 +284,11 @@ export class ImageRenderer {
         if (options.flipY) {
             const flipped = this._flipY(result);
             console.log(`[Render] Total render time: ${(performance.now() - perfStart).toFixed(2)}ms (with flip)`);
+            PerfTrace.mark('render');
             return flipped;
         }
         console.log(`[Render] Total render time: ${(performance.now() - perfStart).toFixed(2)}ms`);
+        PerfTrace.mark('render');
         return result;
     }
 

--- a/media/modules/npy-processor.js
+++ b/media/modules/npy-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 
 /** @typedef {import('./settings-manager.js').SettingsManager} SettingsManager */
 /** @typedef {import('./settings-manager.js').ImageSettings} ImageSettings */
@@ -52,6 +53,8 @@ export class NpyProcessor {
         this._cachedStatsRgb24Mode = false; // Track whether cached stats were computed in rgb24 mode
         /** @type {AbortSignal|undefined} */
         this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+        /** @type {DecodeWorkerClient|null} */
+        this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
     }
 
     /** @param {string} src */
@@ -63,33 +66,18 @@ export class NpyProcessor {
         const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
         if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
-        const view = new DataView(buffer);
 
-        // NPZ (ZIP) signature 0x04034b50
-        if (buffer.byteLength >= 4 && view.getUint32(0, true) === 0x04034b50) {
-            const { data, width, height, dtype, showNorm, channels } = this._parseNpz(buffer);
-            this._lastRaw = { width, height, data, dtype, showNorm, channels };
-
-            const canvas = document.createElement('canvas');
-            canvas.width = width;
-            canvas.height = height;
-
-            // Send format info BEFORE rendering (for deferred rendering)
-            if (this._isInitialLoad) {
-                this._postFormatInfo(width, height, 'NPY');
-                this._pendingRenderData = { data, width, height };
-                // Return placeholder
-                const placeholderImageData = new ImageData(width, height);
-                return { canvas, imageData: placeholderImageData };
-            }
-
-            // Non-initial loads - render immediately
-            const imageData = this._toImageDataFloat(data, width, height);
-            this.vscode.postMessage({ type: 'refresh-status' });
-            return { canvas, imageData };
-        }
-
-        const { data, width, height, dtype, showNorm, channels } = this._parseNpy(buffer);
+        // Parse in the decode worker when available, locally otherwise.
+        // NPY and NPZ (ZIP signature 0x04034b50) share the same result shape.
+        const parsed = await DecodeWorkerClient.decodeWithFallback(
+            this.decodeWorker, 'npy', buffer, src, this.loadSignal,
+            (b) => {
+                const view = new DataView(b);
+                return (b.byteLength >= 4 && view.getUint32(0, true) === 0x04034b50)
+                    ? this._parseNpz(b)
+                    : this._parseNpy(b);
+            });
+        const { data, width, height, dtype, showNorm, channels } = parsed;
         this._lastRaw = { width, height, data, dtype, showNorm, channels };
 
         const canvas = document.createElement('canvas');

--- a/media/modules/npy-processor.js
+++ b/media/modules/npy-processor.js
@@ -59,18 +59,19 @@ export class NpyProcessor {
 
     /** @param {string} src */
     async processNpy(src) {
+        const loadSignal = this.loadSignal;
         // Invalidate stats cache for new image
         this._cachedStats = undefined;
         this._cachedStatsRgb24Mode = false;
 
-        const response = await fetch(src, { signal: this.loadSignal });
+        const response = await fetch(src, { signal: loadSignal });
         const buffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         // Parse in the decode worker when available, locally otherwise.
         // NPY and NPZ (ZIP signature 0x04034b50) share the same result shape.
         const parsed = await DecodeWorkerClient.decodeWithFallback(
-            this.decodeWorker, 'npy', buffer, src, this.loadSignal,
+            this.decodeWorker, 'npy', buffer, src, loadSignal,
             (b) => {
                 const view = new DataView(b);
                 return (b.byteLength >= 4 && view.getUint32(0, true) === 0x04034b50)
@@ -504,5 +505,4 @@ export class NpyProcessor {
         return { r: 255, g: 0, b: 0 }; // Default red
     }
 }
-
 

--- a/media/modules/npy-processor.js
+++ b/media/modules/npy-processor.js
@@ -50,6 +50,8 @@ export class NpyProcessor {
         /** @type {{min: number, max: number} | undefined} */
         this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
         this._cachedStatsRgb24Mode = false; // Track whether cached stats were computed in rgb24 mode
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /** @param {string} src */
@@ -58,8 +60,9 @@ export class NpyProcessor {
         this._cachedStats = undefined;
         this._cachedStatsRgb24Mode = false;
 
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
         const view = new DataView(buffer);
 
         // NPZ (ZIP) signature 0x04034b50

--- a/media/modules/perf-trace.js
+++ b/media/modules/perf-trace.js
@@ -1,0 +1,68 @@
+// @ts-check
+"use strict";
+
+/**
+ * Lightweight phase timer for diagnosing where an image switch spends time.
+ *
+ * One trace is active at a time (image loads are serialized via _loadGeneration
+ * in imagePreview.js — superseded loads abort). mark() and end() are no-ops
+ * when no trace is active, so instrumented code paths need no guards and cost
+ * nothing outside a traced load.
+ *
+ * mark(name) labels the time elapsed since the previous mark (or begin), so
+ * un-instrumented work between two marks is attributed to the later mark —
+ * nothing is hidden from the total.
+ *
+ * Output is a single line per traced load, e.g.:
+ *   [PerfTrace] switch img_004.tif: paint-yield 18ms | fetch 12ms |
+ *   decode-worker 85ms | raster-copy 41ms | stats 33ms | interleave 58ms |
+ *   render 122ms | canvas-upload 9ms | finalize 6ms | total 384ms
+ */
+export class PerfTrace {
+	/** @type {{label: string, start: number, last: number, phases: string[]}|null} */
+	static _active = null;
+
+	/** @type {(message: string) => void} */
+	static _log = (message) => console.log(message);
+
+	/**
+	 * Route summary lines somewhere in addition to / instead of the console
+	 * (e.g. the extension's Output channel via logToOutput).
+	 * @param {(message: string) => void} fn
+	 */
+	static setLogger(fn) {
+		if (fn) { PerfTrace._log = fn; }
+	}
+
+	/** @param {string} label */
+	static begin(label) {
+		const now = performance.now();
+		PerfTrace._active = { label, start: now, last: now, phases: [] };
+	}
+
+	/**
+	 * Record the phase that just finished. No-op when no trace is active.
+	 * @param {string} name
+	 */
+	static mark(name) {
+		const trace = PerfTrace._active;
+		if (!trace) { return; }
+		const now = performance.now();
+		trace.phases.push(`${name} ${(now - trace.last).toFixed(0)}ms`);
+		trace.last = now;
+	}
+
+	/** Log the summary line and deactivate. No-op when no trace is active. */
+	static end() {
+		const trace = PerfTrace._active;
+		if (!trace) { return; }
+		PerfTrace._active = null;
+		const total = (performance.now() - trace.start).toFixed(0);
+		PerfTrace._log(`[PerfTrace] ${trace.label}: ${trace.phases.join(' | ')} | total ${total}ms`);
+	}
+
+	/** Drop the active trace without logging (e.g. load failed or superseded). */
+	static cancel() {
+		PerfTrace._active = null;
+	}
+}

--- a/media/modules/pfm-processor.js
+++ b/media/modules/pfm-processor.js
@@ -32,12 +32,13 @@ export class PfmProcessor {
 
     /** @param {string} src */
     async processPfm(src) {
-        const response = await fetch(src, { signal: this.loadSignal });
+        const loadSignal = this.loadSignal;
+        const response = await fetch(src, { signal: loadSignal });
         const buffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
         // Parse in the decode worker when available, locally otherwise.
         const { width, height, channels, data } = await DecodeWorkerClient.decodeWithFallback(
-            this.decodeWorker, 'pfm', buffer, src, this.loadSignal, (b) => this._parsePfm(b));
+            this.decodeWorker, 'pfm', buffer, src, loadSignal, (b) => this._parsePfm(b));
         // Keep color data for RGB PFM files
         let displayData = data;
 
@@ -294,5 +295,4 @@ export class PfmProcessor {
         return flipped;
     }
 }
-
 

--- a/media/modules/pfm-processor.js
+++ b/media/modules/pfm-processor.js
@@ -23,12 +23,15 @@ export class PfmProcessor {
         this._isInitialLoad = true; // Track if this is the first render
         /** @type {{min: number, max: number} | undefined} */
         this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /** @param {string} src */
     async processPfm(src) {
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
         const { width, height, channels, data } = this._parsePfm(buffer);
         // Keep color data for RGB PFM files
         let displayData = data;

--- a/media/modules/pfm-processor.js
+++ b/media/modules/pfm-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 
 /** @typedef {import('./settings-manager.js').SettingsManager} SettingsManager */
 /** @typedef {import('./settings-manager.js').ImageSettings} ImageSettings */
@@ -25,6 +26,8 @@ export class PfmProcessor {
         this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
         /** @type {AbortSignal|undefined} */
         this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+        /** @type {DecodeWorkerClient|null} */
+        this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
     }
 
     /** @param {string} src */
@@ -32,7 +35,9 @@ export class PfmProcessor {
         const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
         if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
-        const { width, height, channels, data } = this._parsePfm(buffer);
+        // Parse in the decode worker when available, locally otherwise.
+        const { width, height, channels, data } = await DecodeWorkerClient.decodeWithFallback(
+            this.decodeWorker, 'pfm', buffer, src, this.loadSignal, (b) => this._parsePfm(b));
         // Keep color data for RGB PFM files
         let displayData = data;
 

--- a/media/modules/png-processor.js
+++ b/media/modules/png-processor.js
@@ -38,6 +38,8 @@ export class PngProcessor {
         this._lastRenderReusedOriginalImageData = false;
         /** @type {{image: HTMLImageElement, canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, tempCanvas?: HTMLCanvasElement, tempCtx?: CanvasRenderingContext2D | null, width: number, height: number, format: string} | null} */
         this._lazyNativeReadback = null;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /**
@@ -60,8 +62,9 @@ export class PngProcessor {
             this._cachedStats = undefined;
             this._cachedStatsRgb24Mode = false;
 
-            const response = await fetch(src);
+            const response = await fetch(src, { signal: this.loadSignal });
             const arrayBuffer = await response.arrayBuffer();
+            if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
             // Quick bit depth detection from PNG IHDR chunk (just reads byte 24)
             const bitDepth = this._detectPngBitDepth(arrayBuffer);

--- a/media/modules/png-processor.js
+++ b/media/modules/png-processor.js
@@ -52,6 +52,7 @@ export class PngProcessor {
      * @returns {Promise<{canvas: HTMLCanvasElement, imageData: ImageData | null, canvasAlreadyRendered?: boolean, lazyPixelData?: boolean, displayElement?: HTMLElement}>}
      */
     async processPng(src) {
+        const loadSignal = this.loadSignal;
         // JPEG files always use native browser Image API (they don't support 16-bit)
         const isJpeg = src.toLowerCase().includes('.jpg') || src.toLowerCase().includes('.jpeg');
 
@@ -65,9 +66,9 @@ export class PngProcessor {
             this._cachedStats = undefined;
             this._cachedStatsRgb24Mode = false;
 
-            const response = await fetch(src, { signal: this.loadSignal });
+            const response = await fetch(src, { signal: loadSignal });
             const arrayBuffer = await response.arrayBuffer();
-            if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+            if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
             // Quick bit depth detection from PNG IHDR chunk (just reads byte 24)
             const bitDepth = this._detectPngBitDepth(arrayBuffer);
@@ -80,7 +81,7 @@ export class PngProcessor {
             // Decode with UPNG.js — in the decode worker when available,
             // locally otherwise (16-bit path only; 8-bit returned above).
             const png = await DecodeWorkerClient.decodeWithFallback(
-                this.decodeWorker, 'png16', arrayBuffer, src, this.loadSignal,
+                this.decodeWorker, 'png16', arrayBuffer, src, loadSignal,
                 // @ts-ignore
                 (b) => UPNG.decode(b));
 

--- a/media/modules/png-processor.js
+++ b/media/modules/png-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 
 /**
  * @typedef {Object} RawImageData
@@ -40,6 +41,8 @@ export class PngProcessor {
         this._lazyNativeReadback = null;
         /** @type {AbortSignal|undefined} */
         this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+        /** @type {DecodeWorkerClient|null} */
+        this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
     }
 
     /**
@@ -74,9 +77,12 @@ export class PngProcessor {
             }
 
 
-            // Decode with UPNG.js
-            // @ts-ignore
-            const png = UPNG.decode(arrayBuffer);
+            // Decode with UPNG.js — in the decode worker when available,
+            // locally otherwise (16-bit path only; 8-bit returned above).
+            const png = await DecodeWorkerClient.decodeWithFallback(
+                this.decodeWorker, 'png16', arrayBuffer, src, this.loadSignal,
+                // @ts-ignore
+                (b) => UPNG.decode(b));
 
             /*
             png = {

--- a/media/modules/ppm-processor.js
+++ b/media/modules/ppm-processor.js
@@ -1,6 +1,7 @@
 // @ts-check
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
+import { DecodeWorkerClient } from './decode-worker-client.js';
 
 /** @typedef {import('./settings-manager.js').SettingsManager} SettingsManager */
 /** @typedef {{postMessage: (msg: any) => any}} VsCodeApi */
@@ -26,6 +27,8 @@ export class PpmProcessor {
         this._cachedStatsRgb24Mode = false; // Track whether cached stats were computed in rgb24 mode
         /** @type {AbortSignal|undefined} */
         this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+        /** @type {DecodeWorkerClient|null} */
+        this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
     }
 
     /** @param {string} src */
@@ -33,7 +36,9 @@ export class PpmProcessor {
         const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
         if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
-        const { width, height, channels, data, maxval, format } = this._parsePpm(buffer);
+        // Parse in the decode worker when available, locally otherwise.
+        const { width, height, channels, data, maxval, format } = await DecodeWorkerClient.decodeWithFallback(
+            this.decodeWorker, 'ppm', buffer, src, this.loadSignal, (b) => this._parsePpm(b));
 
         // Keep RGB data for color display
         const displayData = data;

--- a/media/modules/ppm-processor.js
+++ b/media/modules/ppm-processor.js
@@ -33,12 +33,13 @@ export class PpmProcessor {
 
     /** @param {string} src */
     async processPpm(src) {
-        const response = await fetch(src, { signal: this.loadSignal });
+        const loadSignal = this.loadSignal;
+        const response = await fetch(src, { signal: loadSignal });
         const buffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
         // Parse in the decode worker when available, locally otherwise.
         const { width, height, channels, data, maxval, format } = await DecodeWorkerClient.decodeWithFallback(
-            this.decodeWorker, 'ppm', buffer, src, this.loadSignal, (b) => this._parsePpm(b));
+            this.decodeWorker, 'ppm', buffer, src, loadSignal, (b) => this._parsePpm(b));
 
         // Keep RGB data for color display
         const displayData = data;

--- a/media/modules/ppm-processor.js
+++ b/media/modules/ppm-processor.js
@@ -24,12 +24,15 @@ export class PpmProcessor {
         /** @type {{min:number,max:number}|undefined} */
         this._cachedStats = undefined; // Cache for min/max stats (only used in stats mode)
         this._cachedStatsRgb24Mode = false; // Track whether cached stats were computed in rgb24 mode
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /** @param {string} src */
     async processPpm(src) {
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         const buffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
         const { width, height, channels, data, maxval, format } = this._parsePpm(buffer);
 
         // Keep RGB data for color display

--- a/media/modules/raw-processor.js
+++ b/media/modules/raw-processor.js
@@ -28,6 +28,8 @@ export class RawProcessor {
         this._workerBootstrapUrl = null;
         /** @type {ArrayBuffer|null} Cached file bytes to avoid re-fetching for full decode */
         this._arrayBuffer = null;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /**
@@ -371,9 +373,10 @@ export class RawProcessor {
      * @returns {Promise<{canvas: HTMLCanvasElement, imageData: ImageData}|null>}
      */
     async extractThumbnail(src) {
-        const response = await fetch(src);
+        const response = await fetch(src, { signal: this.loadSignal });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         this._arrayBuffer = await response.arrayBuffer();
+        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         const jpegBytes = this._extractEmbeddedJpeg(this._arrayBuffer);
         if (!jpegBytes) return null;
@@ -419,11 +422,12 @@ export class RawProcessor {
                 this._arrayBuffer = null; // release reference once consumed
             }
             if (!arrayBuffer) {
-                const response = await fetch(src);
+                const response = await fetch(src, { signal: this.loadSignal });
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);
                 }
                 arrayBuffer = await response.arrayBuffer();
+                if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
                 if (opts.keepBuffer) {
                     this._arrayBuffer = arrayBuffer;
                 }

--- a/media/modules/raw-processor.js
+++ b/media/modules/raw-processor.js
@@ -373,10 +373,11 @@ export class RawProcessor {
      * @returns {Promise<{canvas: HTMLCanvasElement, imageData: ImageData}|null>}
      */
     async extractThumbnail(src) {
-        const response = await fetch(src, { signal: this.loadSignal });
+        const loadSignal = this.loadSignal;
+        const response = await fetch(src, { signal: loadSignal });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         this._arrayBuffer = await response.arrayBuffer();
-        if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+        if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
         const jpegBytes = this._extractEmbeddedJpeg(this._arrayBuffer);
         if (!jpegBytes) return null;
@@ -410,6 +411,7 @@ export class RawProcessor {
      * @param {{keepBuffer?: boolean}} [opts] if keepBuffer, don't clear _arrayBuffer after use
      */
     async processRaw(src, decodeSettings = {}, opts = {}) {
+        const loadSignal = this.loadSignal;
         try {
             this._cachedStats = undefined;
             this._lastRaw = null;
@@ -422,12 +424,12 @@ export class RawProcessor {
                 this._arrayBuffer = null; // release reference once consumed
             }
             if (!arrayBuffer) {
-                const response = await fetch(src, { signal: this.loadSignal });
+                const response = await fetch(src, { signal: loadSignal });
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);
                 }
                 arrayBuffer = await response.arrayBuffer();
-                if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+                if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
                 if (opts.keepBuffer) {
                     this._arrayBuffer = arrayBuffer;
                 }

--- a/media/modules/tga-processor.js
+++ b/media/modules/tga-processor.js
@@ -28,6 +28,8 @@ export class TgaProcessor {
         this._isInitialLoad = true;
         /** @type {{min:number,max:number}|undefined} */
         this._cachedStats = undefined;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
     }
 
     /** @param {string} src */
@@ -35,8 +37,9 @@ export class TgaProcessor {
         try {
             this._cachedStats = undefined;
 
-            const response = await fetch(src);
+            const response = await fetch(src, { signal: this.loadSignal });
             const arrayBuffer = await response.arrayBuffer();
+            if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
             // @ts-ignore
             const tga = new TgaLoader();

--- a/media/modules/tga-processor.js
+++ b/media/modules/tga-processor.js
@@ -34,12 +34,13 @@ export class TgaProcessor {
 
     /** @param {string} src */
     async processTga(src) {
+        const loadSignal = this.loadSignal;
         try {
             this._cachedStats = undefined;
 
-            const response = await fetch(src, { signal: this.loadSignal });
+            const response = await fetch(src, { signal: loadSignal });
             const arrayBuffer = await response.arrayBuffer();
-            if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+            if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 
             // @ts-ignore
             const tga = new TgaLoader();

--- a/media/modules/tiff-processor.js
+++ b/media/modules/tiff-processor.js
@@ -42,6 +42,8 @@ export class TiffProcessor {
 		this._convertedFloatData = null; // Cache converted float data for analysis
 		/** @type {AbortSignal|undefined} */
 		this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
+		/** @type {import('./decode-worker-client.js').DecodeWorkerClient|null} */
+		this.decodeWorker = null; // Off-thread decoder, set by imagePreview.js; null falls back to local decoding
 
 		// WASM decoder
 		this._wasmProcessor = new TiffWasmProcessor();
@@ -112,18 +114,54 @@ export class TiffProcessor {
 			const settings = this.settingsManager.settings;
 			const use24BitMode = settings.rgbAs24BitGrayscale || false;
 
-			let useWasm = this._wasmAvailable && !use24BitMode;
-			console.log(`[TiffProcessor] Decode decision: wasmAvailable=${this._wasmAvailable}, 24BitMode=${use24BitMode}, willUseWasm=${useWasm}`);
+			// Try the decode worker first: the same Rust/WASM decoder, but off
+			// the UI thread so big decodes don't freeze input handling or
+			// painting. On failure the worker transfers the bytes back and we
+			// fall straight through to geotiff.js — retrying the identical
+			// WASM decoder locally would just fail again.
+			/** @type {any} */
+			let wasmResult = null;
+			let workerTiffFailed = false;
+			/** @type {ArrayBuffer|null} */
+			let localBuffer = buffer;
+			if (!use24BitMode && this.decodeWorker?.canDecode('tiff')) {
+				const workerStart = performance.now();
+				const workerResponse = await this.decodeWorker.decode('tiff', buffer);
+				if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+				if (workerResponse?.ok) {
+					wasmResult = workerResponse.result;
+					localBuffer = null;
+					console.log(`[TiffProcessor] Worker WASM decode time: ${(performance.now() - workerStart).toFixed(2)}ms`);
+				} else {
+					workerTiffFailed = true;
+					localBuffer = (workerResponse?.buffer && workerResponse.buffer.byteLength > 0) ? workerResponse.buffer : null;
+					console.warn('[TiffProcessor] Worker decode failed, falling back to geotiff.js:', workerResponse?.error);
+				}
+			}
 
-			// Try WASM decoding first if available
-			if (useWasm) {
+			const useWasm = !wasmResult && !workerTiffFailed && this._wasmAvailable && !use24BitMode;
+			console.log(`[TiffProcessor] Decode decision: worker=${!!wasmResult}, wasmAvailable=${this._wasmAvailable}, 24BitMode=${use24BitMode}, willUseWasm=${useWasm}`);
+
+			// Local WASM decoding when the worker isn't available
+			if (useWasm && localBuffer) {
 				try {
 					const decodeStart = performance.now();
 					// Use a copy so a WASM failure/memory-growth cannot invalidate the
 					// original buffer that the geotiff.js fallback path needs below.
-					const wasmResult = await this._wasmProcessor.decode(buffer.slice(0));
+					wasmResult = await this._wasmProcessor.decode(localBuffer.slice(0));
 					const decodeTime = performance.now() - decodeStart;
 					console.log(`[TiffProcessor] WASM decode time: ${decodeTime.toFixed(2)}ms`);
+				} catch (wasmError) {
+					console.warn('[TiffProcessor] WASM decoding failed, falling back to geotiff.js:', wasmError);
+					// Disable WASM for the rest of the session — a failure can leave
+					// the module in an indeterminate state after a panic.
+					this._wasmAvailable = false;
+					wasmResult = null;
+				}
+			}
+
+			if (wasmResult) {
+				try {
 
 					// Convert WASM result to format compatible with existing code
 					const width = wasmResult.width;
@@ -132,11 +170,16 @@ export class TiffProcessor {
 					const bitsPerSample = wasmResult.bitsPerSample;
 					const sampleFormat = wasmResult.sampleFormat;
 
-					// Create rasters from WASM data (deinterleave if needed)
-					const rasters = [];
-					if (samplesPerPixel === 1) {
-						rasters.push(wasmResult.data);
+					// Per-channel rasters: the worker already deinterleaved them
+					// off-thread; the local WASM path deinterleaves here.
+					/** @type {Float32Array[]} */
+					let rasters;
+					if (wasmResult.rasters) {
+						rasters = wasmResult.rasters;
+					} else if (samplesPerPixel === 1) {
+						rasters = [wasmResult.data];
 					} else {
+						rasters = [];
 						// Deinterleave for compatibility with existing rendering code
 						for (let c = 0; c < samplesPerPixel; c++) {
 							const channel = new Float32Array(width * height);
@@ -200,7 +243,7 @@ export class TiffProcessor {
 								bitsPerSample,
 								formatType,
 								isInitialLoad: true,
-								decodedWith: 'wasm'
+								decodedWith: wasmResult.decodedWith || 'wasm'
 							}
 						});
 
@@ -230,8 +273,13 @@ export class TiffProcessor {
 			}
 
 			// Fallback to geotiff.js (or if WASM not available/failed)
+			if (!localBuffer || localBuffer.byteLength === 0) {
+				// The bytes were transferred to the worker; refetch (rare error path).
+				const refetched = await fetch(src, { signal: this.loadSignal });
+				localBuffer = await refetched.arrayBuffer();
+			}
 			const decodeStart = performance.now();
-			const tiff = await GeoTIFF.fromArrayBuffer(buffer);
+			const tiff = await GeoTIFF.fromArrayBuffer(localBuffer);
 			const image = await tiff.getImage();
 			const sampleFormat = image.getSampleFormat();
 

--- a/media/modules/tiff-processor.js
+++ b/media/modules/tiff-processor.js
@@ -40,6 +40,8 @@ export class TiffProcessor {
 		this._lastStatisticsRgb24Mode = false; // Track whether cached stats were computed in rgb24 mode
 		/** @type {{ floatData: Float32Array, width?: number, height?: number, min?: number, max?: number } | null} */
 		this._convertedFloatData = null; // Cache converted float data for analysis
+		/** @type {AbortSignal|undefined} */
+		this.loadSignal = undefined; // Set before each load; aborts the fetch when a newer image switch supersedes it
 
 		// WASM decoder
 		this._wasmProcessor = new TiffWasmProcessor();
@@ -94,8 +96,9 @@ export class TiffProcessor {
 	async processTiff(src) {
 		const startTime = performance.now();
 		try {
-			const response = await fetch(src);
+			const response = await fetch(src, { signal: this.loadSignal });
 			const buffer = await response.arrayBuffer();
+			if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 			const fetchTime = performance.now() - startTime;
 			console.log(`[TiffProcessor] Fetch time: ${fetchTime.toFixed(2)}ms`);
 

--- a/media/modules/tiff-processor.js
+++ b/media/modules/tiff-processor.js
@@ -98,19 +98,14 @@ export class TiffProcessor {
 	 */
 	async processTiff(src) {
 		const startTime = performance.now();
+		const loadSignal = this.loadSignal;
 		try {
-			const response = await fetch(src, { signal: this.loadSignal });
+			const response = await fetch(src, { signal: loadSignal });
 			const buffer = await response.arrayBuffer();
-			if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+			if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 			const fetchTime = performance.now() - startTime;
 			console.log(`[TiffProcessor] Fetch time: ${fetchTime.toFixed(2)}ms`);
 			PerfTrace.mark('fetch');
-
-			// Wait for WASM initialization if it's in progress
-			if (!this._wasmAvailable && this._wasmProcessor) {
-				await this._wasmProcessor.init();
-				this._wasmAvailable = this._wasmProcessor.isAvailable();
-			}
 
 			// Check if we should use WASM decoder
 			const settings = this.settingsManager.settings;
@@ -121,6 +116,15 @@ export class TiffProcessor {
 			// painting. On failure the worker transfers the bytes back and we
 			// fall straight through to geotiff.js — retrying the identical
 			// WASM decoder locally would just fail again.
+			// Wait for worker startup so an early load does not take a
+			// synchronous main-thread decoder merely because boot is in flight.
+			if (this.decodeWorker && !this.decodeWorker.canDecode('tiff')) {
+				await Promise.race([
+					this.decodeWorker.start(),
+					new Promise(resolve => setTimeout(resolve, 500)),
+				]);
+			}
+			if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 			/** @type {any} */
 			let wasmResult = null;
 			let workerTiffFailed = false;
@@ -129,12 +133,20 @@ export class TiffProcessor {
 			if (!use24BitMode && this.decodeWorker?.canDecode('tiff')) {
 				const workerStart = performance.now();
 				const workerResponse = await this.decodeWorker.decode('tiff', buffer);
-				if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
+				if (loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 				if (workerResponse?.ok) {
 					wasmResult = workerResponse.result;
 					localBuffer = null;
-					console.log(`[TiffProcessor] Worker WASM decode time: ${(performance.now() - workerStart).toFixed(2)}ms`);
-					PerfTrace.mark('decode-worker');
+					const decodedWith = wasmResult.decodedWith || 'wasm (worker)';
+					console.log(`[TiffProcessor] Worker TIFF decode time: ${(performance.now() - workerStart).toFixed(2)}ms (${decodedWith})`);
+					if (wasmResult.wasmFallbackReason) {
+						console.warn('[TiffProcessor] Worker used geotiff.js because WASM rejected the TIFF:', wasmResult.wasmFallbackReason);
+						this.vscode?.postMessage({
+							type: 'log',
+							value: `[TiffProcessor] WASM rejected TIFF; using geotiff.js worker fallback: ${wasmResult.wasmFallbackReason}`,
+						});
+					}
+					PerfTrace.mark(decodedWith.startsWith('geotiff.js') ? 'decode-geotiff-worker' : 'decode-wasm-worker');
 				} else {
 					workerTiffFailed = true;
 					localBuffer = (workerResponse?.buffer && workerResponse.buffer.byteLength > 0) ? workerResponse.buffer : null;
@@ -233,6 +245,7 @@ export class TiffProcessor {
 					if (this.vscode && this._isInitialLoad) {
 						const showNormTiff = sampleFormat === 3;
 						const formatType = showNormTiff ? 'tiff-float' : 'tiff-int';
+						this._pendingRenderData = { image, rasters };
 
 						this.vscode.postMessage({
 							type: 'formatInfo',
@@ -251,8 +264,6 @@ export class TiffProcessor {
 								decodedWith: wasmResult.decodedWith || 'wasm'
 							}
 						});
-
-						this._pendingRenderData = { image, rasters };
 
 						const canvas = document.createElement('canvas');
 						canvas.width = width;
@@ -280,7 +291,7 @@ export class TiffProcessor {
 			// Fallback to geotiff.js (or if WASM not available/failed)
 			if (!localBuffer || localBuffer.byteLength === 0) {
 				// The bytes were transferred to the worker; refetch (rare error path).
-				const refetched = await fetch(src, { signal: this.loadSignal });
+				const refetched = await fetch(src, { signal: loadSignal });
 				localBuffer = await refetched.arrayBuffer();
 			}
 			const decodeStart = performance.now();
@@ -355,6 +366,7 @@ export class TiffProcessor {
 				// Determine if this is a float TIFF or int TIFF
 				const showNormTiff = sampleFormat === 3; // 3 = IEEE floating point
 				const formatType = showNormTiff ? 'tiff-float' : 'tiff-int';
+				this._pendingRenderData = { image, rasters };
 
 				this.vscode.postMessage({
 					type: 'formatInfo',
@@ -373,9 +385,6 @@ export class TiffProcessor {
 						decodedWith: use24BitMode ? 'geotiff.js (24-bit mode)' : 'geotiff.js'
 					}
 				});
-
-				// Store pending render data - will render when settings are updated
-				this._pendingRenderData = { image, rasters };
 
 				// Return placeholder - actual rendering happens when settings update
 				const placeholderImageData = new ImageData(width, height);
@@ -814,4 +823,4 @@ export class TiffProcessor {
 		console.log(`[TiffProcessor] Deferred render took ${(performance.now() - perfStart).toFixed(2)}ms`);
 		return imageData;
 	}
-} 
+}

--- a/media/modules/tiff-processor.js
+++ b/media/modules/tiff-processor.js
@@ -2,6 +2,7 @@
 "use strict";
 import { NormalizationHelper, ImageRenderer, ImageStatsCalculator } from './normalization-helper.js';
 import { TiffWasmProcessor } from './tiff-wasm-wrapper.js';
+import { PerfTrace } from './perf-trace.js';
 
 /**
  * @typedef {Object} GeoTIFFGlobal
@@ -103,6 +104,7 @@ export class TiffProcessor {
 			if (this.loadSignal?.aborted) { throw new DOMException('Load superseded', 'AbortError'); }
 			const fetchTime = performance.now() - startTime;
 			console.log(`[TiffProcessor] Fetch time: ${fetchTime.toFixed(2)}ms`);
+			PerfTrace.mark('fetch');
 
 			// Wait for WASM initialization if it's in progress
 			if (!this._wasmAvailable && this._wasmProcessor) {
@@ -132,6 +134,7 @@ export class TiffProcessor {
 					wasmResult = workerResponse.result;
 					localBuffer = null;
 					console.log(`[TiffProcessor] Worker WASM decode time: ${(performance.now() - workerStart).toFixed(2)}ms`);
+					PerfTrace.mark('decode-worker');
 				} else {
 					workerTiffFailed = true;
 					localBuffer = (workerResponse?.buffer && workerResponse.buffer.byteLength > 0) ? workerResponse.buffer : null;
@@ -151,6 +154,7 @@ export class TiffProcessor {
 					wasmResult = await this._wasmProcessor.decode(localBuffer.slice(0));
 					const decodeTime = performance.now() - decodeStart;
 					console.log(`[TiffProcessor] WASM decode time: ${decodeTime.toFixed(2)}ms`);
+					PerfTrace.mark('decode-wasm-local');
 				} catch (wasmError) {
 					console.warn('[TiffProcessor] WASM decoding failed, falling back to geotiff.js:', wasmError);
 					// Disable WASM for the rest of the session — a failure can leave
@@ -188,6 +192,7 @@ export class TiffProcessor {
 							}
 							rasters.push(channel);
 						}
+						PerfTrace.mark('deinterleave');
 					}
 
 					// Store interleaved data
@@ -300,6 +305,7 @@ export class TiffProcessor {
 			const rasters = await image.readRasters();
 			const decodeTime = performance.now() - decodeStart;
 			console.log(`[TiffProcessor] geotiff.js decode time: ${decodeTime.toFixed(2)}ms`);
+			PerfTrace.mark('decode-geotiff');
 
 			const samplesPerPixel = image.getSamplesPerPixel();
 			const bitsPerSample = image.getBitsPerSample();
@@ -326,6 +332,7 @@ export class TiffProcessor {
 					}
 				}
 			}
+			PerfTrace.mark('interleave-raw');
 
 			// Store TIFF data for pixel inspection and re-rendering
 			this.rawTiffData = {
@@ -398,6 +405,7 @@ export class TiffProcessor {
 		for (let i = 0; i < rasters.length; i++) {
 			rastersCopy.push(new Float32Array(rasters[i]));
 		}
+		PerfTrace.mark('raster-copy');
 
 		// Apply mask filtering if enabled
 		const settings = this.settingsManager.settings;
@@ -446,6 +454,7 @@ export class TiffProcessor {
 					}
 				}
 			}
+			PerfTrace.mark('finite-scan');
 		}
 
 		// Calculate stats if needed (for auto-normalize or just to have them)
@@ -547,6 +556,7 @@ export class TiffProcessor {
 
 			this._lastStatistics = stats;
 			this._lastStatisticsRgb24Mode = currentRgb24Mode;
+			PerfTrace.mark('stats');
 		}
 
 		// Send stats to VS Code
@@ -582,6 +592,7 @@ export class TiffProcessor {
 				}
 			}
 		}
+		PerfTrace.mark('interleave');
 
 		// Create options object
 		const options = {

--- a/media/modules/web-image-processor.js
+++ b/media/modules/web-image-processor.js
@@ -29,6 +29,8 @@ export class WebImageProcessor {
         this._isInitialLoad = true;
         /** @type {{min:number,max:number}|undefined} */
         this._cachedStats = undefined;
+        /** @type {AbortSignal|undefined} */
+        this.loadSignal = undefined; // Set before each load; superseded loads are discarded by the caller's generation check
     }
 
     /** @param {string} src */

--- a/media/modules/worker-shims.js
+++ b/media/modules/worker-shims.js
@@ -1,0 +1,11 @@
+// @ts-check
+"use strict";
+
+// Minimal browser-global shim so window-attaching vendored libraries
+// (parse-exr.js) can run inside a Web Worker, where `window` does not exist.
+// Imported first in decode-worker.js — ES module import order guarantees it
+// runs before the libraries that need it.
+if (typeof globalThis.window === 'undefined') {
+	// @ts-ignore
+	globalThis.window = globalThis;
+}

--- a/package.json
+++ b/package.json
@@ -220,13 +220,13 @@
         {
           "command": "tiffVisualizer.browseAndAddToCollection",
           "title": "Add Image to Visualizer Collection",
-          "when": "resourceExtname =~ /^\\.(png|jpe?g|tiff?|exr|pfm|npy|npz|pp[mgb]|hdr|tga|webp|avif|bmp|ico|jxl)$/i && tiffVisualizer.hasActivePreview",
+          "when": "resourceExtname =~ /^\\.(png|jpe?g|tiff?|exr|pfm|npy|npz|pp[mgb]|hdr|tga|webp|avif|bmp|ico|jxl)$/i",
           "group": "navigation@1"
         },
         {
           "command": "tiffVisualizer.browseAndAddToCollection",
           "title": "Add Folder Images to Visualizer Collection",
-          "when": "explorerResourceIsFolder && tiffVisualizer.hasActivePreview",
+          "when": "explorerResourceIsFolder",
           "group": "navigation@1"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -222,6 +222,12 @@
           "title": "Add Image to Visualizer Collection",
           "when": "resourceExtname =~ /^\\.(png|jpe?g|tiff?|exr|pfm|npy|npz|pp[mgb]|hdr|tga|webp|avif|bmp|ico|jxl)$/i && tiffVisualizer.hasActivePreview",
           "group": "navigation@1"
+        },
+        {
+          "command": "tiffVisualizer.browseAndAddToCollection",
+          "title": "Add Folder Images to Visualizer Collection",
+          "when": "explorerResourceIsFolder && tiffVisualizer.hasActivePreview",
+          "group": "navigation@1"
         }
       ],
       "editor/context": [

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -213,6 +213,63 @@ async function expandGlobPatternAsync(pattern: string, isCancelled: () => boolea
 	return results.sort((a, b) => a.fsPath.localeCompare(b.fsPath, undefined, { numeric: true }));
 }
 
+/** Returns the final path segment of a URI (scheme-agnostic). */
+function uriBasename(uri: vscode.Uri): string {
+	return uri.path.split('/').pop() || uri.path;
+}
+
+/**
+ * Adds a list of image URIs to the given preview's collection, showing progress
+ * for multi-file operations and a summary message at the end.
+ * Shared by the Explorer context-menu path and the wildcard pattern picker.
+ */
+async function addUrisToCollection(
+	activePreview: { addToImageCollection(uri: vscode.Uri): Promise<boolean> },
+	uris: vscode.Uri[],
+): Promise<{ added: number; skipped: number }> {
+	const result = { added: 0, skipped: 0 };
+	if (uris.length === 0) {
+		return result;
+	}
+
+	let firstAdded: vscode.Uri | undefined;
+	await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Adding to collection…', cancellable: true },
+		async (progress, token) => {
+			for (const uri of uris) {
+				if (token.isCancellationRequested) { break; }
+				if (uris.length > 1) {
+					progress.report({ message: `Adding ${result.added + result.skipped + 1} / ${uris.length}…`, increment: 100 / uris.length });
+				}
+				try {
+					const wasAdded = await activePreview.addToImageCollection(uri);
+					if (wasAdded) { if (!firstAdded) { firstAdded = uri; } result.added++; } else { result.skipped++; }
+				} catch (error) {
+					logCommand('browseAndAddToCollection', 'error', `Failed to add ${uri.fsPath}: ${error}`);
+				}
+			}
+		}
+	);
+
+	const { added, skipped } = result;
+	if (added === 0 && skipped > 0) {
+		const msg = skipped === 1
+			? `${uriBasename(uris[0])} is already in the collection.`
+			: `All ${skipped} images are already in the collection.`;
+		vscode.window.showWarningMessage(msg);
+	} else if (added > 0) {
+		vscode.commands.executeCommand('workbench.action.keepEditor');
+		const base = added === 1
+			? `Added ${uriBasename(firstAdded!)} to image collection.`
+			: `Added ${added} images to collection.`;
+		const msg = skipped > 0
+			? `${base} (${skipped} already in collection, skipped) Press ← → to navigate.`
+			: `${base} Press ← → to navigate.`;
+		vscode.window.showInformationMessage(msg);
+	}
+	return result;
+}
+
 /**
  * Logs command execution to the output channel
  */
@@ -1310,7 +1367,7 @@ export function registerImagePreviewCommands(
 		});
 	}
 
-	disposables.push(vscode.commands.registerCommand('tiffVisualizer.browseAndAddToCollection', async (resource?: vscode.Uri) => {
+	disposables.push(vscode.commands.registerCommand('tiffVisualizer.browseAndAddToCollection', async (resource?: vscode.Uri, resources?: vscode.Uri[]) => {
 		logCommand('browseAndAddToCollection', 'start');
 		const activePreview = previewManager.activePreview;
 		if (!activePreview) {
@@ -1319,19 +1376,18 @@ export function registerImagePreviewCommands(
 			return;
 		}
 
-		// When invoked from the Explorer context menu, resource is the right-clicked file — add it directly.
-		if (resource) {
+		// When invoked from the Explorer context menu, VS Code passes the clicked
+		// resource as the first argument and, when several entries are selected,
+		// the full selection as the second argument. Honor the whole selection so
+		// users can Ctrl/Shift-select multiple files and add them all at once.
+		const selectedResources = (resources && resources.length > 0)
+			? resources
+			: (resource ? [resource] : []);
+
+		if (selectedResources.length > 0) {
 			try {
-				const filename = resource.fsPath.split(path.sep).pop() ?? resource.fsPath;
-				const wasAdded = await activePreview.addToImageCollection(resource);
-				if (wasAdded) {
-					vscode.commands.executeCommand('workbench.action.keepEditor');
-					vscode.window.showInformationMessage(`Added ${filename} to image collection. Press ← → to navigate.`);
-					logCommand('browseAndAddToCollection', 'success', resource.fsPath);
-				} else {
-					vscode.window.showWarningMessage(`${filename} is already in the collection.`);
-					logCommand('browseAndAddToCollection', 'success', `duplicate: ${resource.fsPath}`);
-				}
+				const { added, skipped } = await addUrisToCollection(activePreview, selectedResources);
+				logCommand('browseAndAddToCollection', 'success', `explorer: added ${added}, skipped ${skipped}`);
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to add images to collection: ${error}`);
 				logCommand('browseAndAddToCollection', 'error', String(error));
@@ -1341,57 +1397,17 @@ export function registerImagePreviewCommands(
 
 		const currentDir = path.dirname(activePreview.resource.fsPath);
 		const pattern = await pickPathWithAutocomplete(currentDir, activePreview.imageCollection);
-		if (!pattern) return;
+		if (!pattern) { return; }
 
-		await vscode.window.withProgress(
-			{ location: vscode.ProgressLocation.Notification, title: 'Adding to collection…', cancellable: true },
-			async (progress, token) => {
-				const isCancelled = () => token.isCancellationRequested;
+		const filesToAdd = await expandGlobPatternAsync(pattern, () => false);
+		if (filesToAdd.length === 0) {
+			vscode.window.showWarningMessage(`No image files found matching: ${pattern}`);
+			logCommand('browseAndAddToCollection', 'error', `No files matching: ${pattern}`);
+			return;
+		}
 
-				progress.report({ message: 'Scanning files…' });
-				const filesToAdd = await expandGlobPatternAsync(pattern, isCancelled);
-
-				if (isCancelled()) return;
-
-				if (filesToAdd.length === 0) {
-					vscode.window.showWarningMessage(`No image files found matching: ${pattern}`);
-					logCommand('browseAndAddToCollection', 'error', `No files matching: ${pattern}`);
-					return;
-				}
-
-				let added = 0;
-				let skipped = 0;
-				let firstAdded: vscode.Uri | undefined;
-				for (const uri of filesToAdd) {
-					if (isCancelled()) break;
-					progress.report({ message: `Adding ${added + skipped + 1} / ${filesToAdd.length}…`, increment: 100 / filesToAdd.length });
-					try {
-						const wasAdded = await activePreview.addToImageCollection(uri);
-						if (wasAdded) { if (!firstAdded) { firstAdded = uri; } added++; } else { skipped++; }
-					} catch (error) {
-						logCommand('browseAndAddToCollection', 'error', `Failed to add ${uri.fsPath}: ${error}`);
-					}
-				}
-
-				if (added > 0 || skipped > 0) {
-					let msg: string;
-					if (added === 0) {
-						msg = skipped === 1
-							? `${filesToAdd[0].fsPath.split(path.sep).pop()} is already in the collection.`
-							: `All ${skipped} images are already in the collection.`;
-						vscode.window.showWarningMessage(msg);
-					} else {
-						vscode.commands.executeCommand('workbench.action.keepEditor');
-						const base = added === 1
-							? `Added ${firstAdded!.fsPath.split(path.sep).pop()} to image collection.`
-							: `Added ${added} images to collection.`;
-						msg = skipped > 0 ? `${base} (${skipped} already in collection, skipped) Press ← → to navigate.` : `${base} Press ← → to navigate.`;
-						vscode.window.showInformationMessage(msg);
-					}
-					logCommand('browseAndAddToCollection', 'success', `Added ${added}, skipped ${skipped}`);
-				}
-			}
-		);
+		const { added, skipped } = await addUrisToCollection(activePreview, filesToAdd);
+		logCommand('browseAndAddToCollection', 'success', `Added ${added}, skipped ${skipped}`);
 	}));
 
 	// Comparison Panel Commands

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -221,8 +221,22 @@ async function expandGlobSegmentsAsync(
 async function expandGlobPatternAsync(pattern: string, anchor: vscode.Uri, isCancelled: () => boolean): Promise<vscode.Uri[]> {
 	const pp = pathModuleFor(anchor);
 	if (!pattern.includes('*') && !pattern.includes('?')) {
-		const st = await statPath(pattern, anchor);
-		return st && (st.type & vscode.FileType.File) ? [pathToUri(pattern, anchor)] : [];
+		const plain = pattern.replace(/[/\\]+$/, '') || pp.sep;
+		const st = await statPath(plain, anchor);
+		if (!st) return [];
+		if (st.type & vscode.FileType.Directory) {
+			// A plain folder path expands to every supported image directly
+			// inside it (non-recursive, mirroring the Explorer context menu).
+			const results: vscode.Uri[] = [];
+			for (const [name, fileType] of await readDirPath(plain, anchor)) {
+				if (isCancelled() || results.length >= MAX_GLOB_RESULTS) break;
+				if ((fileType & vscode.FileType.File) === 0) continue;
+				const uri = pathToUri(pp.join(plain, name), anchor);
+				if (isImageUri(uri)) results.push(uri);
+			}
+			return results.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
+		}
+		return (st.type & vscode.FileType.File) ? [pathToUri(plain, anchor)] : [];
 	}
 
 	const firstWild = pattern.search(/[*?]/);
@@ -1260,7 +1274,7 @@ export function registerImagePreviewCommands(
 		const initialDir = pp.dirname(anchor.scheme === 'file' ? anchor.fsPath : anchor.path);
 		return new Promise<string | undefined>((resolve) => {
 			const qp = vscode.window.createQuickPick();
-			qp.placeholder = 'Type a path or wildcard pattern (e.g. *.tiff)';
+			qp.placeholder = 'Type a file path, folder, or wildcard pattern (e.g. *.tiff)';
 			qp.value = initialDir + sep;
 			qp.matchOnDescription = false;
 			qp.matchOnDetail = false;
@@ -1333,7 +1347,7 @@ export function registerImagePreviewCommands(
 									contentItems.push({
 										label: '$(folder) ' + name,
 										description: fullPath,
-										detail: 'Directory — select to navigate into it',
+										detail: 'Folder — select to navigate into it, or confirm the typed path to add all images inside',
 										alwaysShow: true,
 									} as vscode.QuickPickItem & { _dirPath?: string });
 									(contentItems[contentItems.length - 1] as any)._dirPath = fullPath;
@@ -1352,7 +1366,8 @@ export function registerImagePreviewCommands(
 
 				if (searchVersion !== version) return;
 
-				// Detect if the typed path is a plain directory (no wildcards)
+				// Detect if the typed path is a plain directory (no wildcards) —
+				// folders are accepted and expand to all images directly inside.
 				let isDirectoryPath = false;
 				if (typed && !typed.includes('*') && !typed.includes('?')) {
 					const st = await statPath(typed.replace(/[/\\]+$/, '') || sep, anchor);
@@ -1360,34 +1375,27 @@ export function registerImagePreviewCommands(
 					if (searchVersion !== version) return;
 				}
 
-				let finalUseItem: vscode.QuickPickItem;
-				if (isDirectoryPath) {
-					finalUseItem = {
-						label: '$(warning) This is a folder, not a file',
-						description: 'Add * or *.ext at the end to match images inside',
-						alwaysShow: true,
-					};
-					(finalUseItem as any)._useRaw = false; // not selectable as a pattern
+				const files = await expandGlobPatternAsync(typed, anchor, isCancelled);
+				if (searchVersion !== version) return;
+				const existingSet = new Set(existingCollection.map(u => u.toString()));
+				const newCount = files.filter(u => !existingSet.has(u.toString())).length;
+				const alreadyCount = files.length - newCount;
+				const fromFolder = isDirectoryPath ? ' from this folder' : '';
+				let useLabel: string;
+				if (files.length === 0) {
+					useLabel = isDirectoryPath
+						? '$(warning) No supported images in this folder'
+						: '$(check) Use this pattern';
+				} else if (alreadyCount === 0) {
+					useLabel = `$(check) Add ${newCount} image${newCount === 1 ? '' : 's'}${fromFolder}`;
+				} else if (newCount === 0) {
+					useLabel = `$(warning) All ${alreadyCount} image${alreadyCount === 1 ? '' : 's'} already in collection`;
 				} else {
-					const files = await expandGlobPatternAsync(typed, anchor, isCancelled);
-					if (searchVersion !== version) return;
-					const existingSet = new Set(existingCollection.map(u => u.toString()));
-					const newCount = files.filter(u => !existingSet.has(u.toString())).length;
-					const alreadyCount = files.length - newCount;
-					let useLabel: string;
-					if (files.length === 0) {
-						useLabel = '$(check) Use this pattern';
-					} else if (alreadyCount === 0) {
-						useLabel = `$(check) Add ${newCount} image${newCount === 1 ? '' : 's'}`;
-					} else if (newCount === 0) {
-						useLabel = `$(warning) All ${alreadyCount} image${alreadyCount === 1 ? '' : 's'} already in collection`;
-					} else {
-						useLabel = `$(check) Add ${newCount} new image${newCount === 1 ? '' : 's'} (${alreadyCount} already in collection)`;
-					}
-					const canConfirm = newCount > 0;
-					finalUseItem = { label: useLabel, description: canConfirm ? 'Press Enter to confirm' : undefined, alwaysShow: true };
-					(finalUseItem as any)._useRaw = canConfirm;
+					useLabel = `$(check) Add ${newCount} new image${newCount === 1 ? '' : 's'}${fromFolder} (${alreadyCount} already in collection)`;
 				}
+				const canConfirm = newCount > 0;
+				const finalUseItem: vscode.QuickPickItem = { label: useLabel, description: canConfirm ? 'Press Enter to confirm' : undefined, alwaysShow: true };
+				(finalUseItem as any)._useRaw = canConfirm;
 				qp.items = [finalUseItem, ...contentItems];
 			}
 

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import { Utils } from 'vscode-uri';
 import { BinarySizeStatusBarEntry } from '../binarySizeStatusBarEntry';
 import { SizeStatusBarEntry } from './sizeStatusBarEntry';
 import { ImagePreviewManager } from './imagePreviewManager';
@@ -216,6 +217,47 @@ async function expandGlobPatternAsync(pattern: string, isCancelled: () => boolea
 /** Returns the final path segment of a URI (scheme-agnostic). */
 function uriBasename(uri: vscode.Uri): string {
 	return uri.path.split('/').pop() || uri.path;
+}
+
+/** True if the URI's extension is one of the supported image formats. */
+function isImageUri(uri: vscode.Uri): boolean {
+	const ext = uriBasename(uri).split('.').pop()?.toLowerCase() ?? '';
+	return IMAGE_EXTENSIONS.includes(ext);
+}
+
+/**
+ * Expands a selection of URIs into a flat, sorted list of image-file URIs.
+ * Directories are scanned (non-recursively) for supported image files via the
+ * VS Code filesystem API, so it works for local, remote (SSH) and virtual
+ * workspaces alike. Plain image files pass through unchanged; anything else is
+ * dropped. Duplicates are removed.
+ */
+async function collectImageFiles(uris: vscode.Uri[]): Promise<vscode.Uri[]> {
+	const out = new Map<string, vscode.Uri>();
+	for (const uri of uris) {
+		let type: vscode.FileType;
+		try {
+			type = (await vscode.workspace.fs.stat(uri)).type;
+		} catch {
+			continue;
+		}
+		if (type & vscode.FileType.Directory) {
+			let entries: [string, vscode.FileType][];
+			try {
+				entries = await vscode.workspace.fs.readDirectory(uri);
+			} catch {
+				continue;
+			}
+			for (const [name, entryType] of entries) {
+				if ((entryType & vscode.FileType.File) === 0) { continue; }
+				const child = Utils.joinPath(uri, name);
+				if (isImageUri(child)) { out.set(child.toString(), child); }
+			}
+		} else if ((type & vscode.FileType.File) && isImageUri(uri)) {
+			out.set(uri.toString(), uri);
+		}
+	}
+	return [...out.values()].sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
 }
 
 /**
@@ -1386,7 +1428,15 @@ export function registerImagePreviewCommands(
 
 		if (selectedResources.length > 0) {
 			try {
-				const { added, skipped } = await addUrisToCollection(activePreview, selectedResources);
+				// Selection may include folders (right-clicked or multi-selected) —
+				// expand them into the image files they contain.
+				const files = await collectImageFiles(selectedResources);
+				if (files.length === 0) {
+					vscode.window.showWarningMessage('No supported image files found in the selection.');
+					logCommand('browseAndAddToCollection', 'error', 'No image files in selection');
+					return;
+				}
+				const { added, skipped } = await addUrisToCollection(activePreview, files);
 				logCommand('browseAndAddToCollection', 'success', `explorer: added ${added}, skipped ${skipped}`);
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to add images to collection: ${error}`);

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -243,7 +243,9 @@ async function expandGlobPatternAsync(pattern: string, anchor: vscode.Uri, isCan
 	const beforeWild = pattern.substring(0, firstWild);
 	const endsWithSep = beforeWild.endsWith('/') || beforeWild.endsWith('\\');
 	const baseDir = pp.dirname(endsWithSep ? beforeWild + '_' : beforeWild);
-	const remainder = pattern.substring(baseDir.length + 1);
+	// dirname of a root-level path returns the root itself ('/' or 'C:\'),
+	// which already ends with a separator — don't skip an extra character.
+	const remainder = pattern.substring(baseDir.endsWith(pp.sep) ? baseDir.length : baseDir.length + 1);
 	const segments = remainder.split(/[/\\]/);
 
 	const results: vscode.Uri[] = [];

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -1426,19 +1426,28 @@ export function registerImagePreviewCommands(
 		});
 	}
 
+	/**
+	 * Opens an image in the TIFF Visualizer custom editor and returns its preview
+	 * once registered. Used to bootstrap a collection when no preview is open yet.
+	 */
+	async function openPreviewForResource(uri: vscode.Uri) {
+		await vscode.commands.executeCommand('vscode.openWith', uri, ImagePreviewManager.viewType);
+		// resolveCustomEditor runs asynchronously — wait briefly for the preview to register.
+		for (let i = 0; i < 60; i++) {
+			const preview = previewManager.getPreviewFor(uri) ?? previewManager.activePreview;
+			if (preview) { return preview; }
+			await new Promise(r => setTimeout(r, 50));
+		}
+		return previewManager.getPreviewFor(uri) ?? previewManager.activePreview;
+	}
+
 	disposables.push(vscode.commands.registerCommand('tiffVisualizer.browseAndAddToCollection', async (resource?: vscode.Uri, resources?: vscode.Uri[]) => {
 		logCommand('browseAndAddToCollection', 'start');
-		const activePreview = previewManager.activePreview;
-		if (!activePreview) {
-			vscode.window.showErrorMessage('No active TIFF Visualizer preview found. Please open an image first.');
-			logCommand('browseAndAddToCollection', 'error', 'No active preview');
-			return;
-		}
 
 		// When invoked from the Explorer context menu, VS Code passes the clicked
 		// resource as the first argument and, when several entries are selected,
 		// the full selection as the second argument. Honor the whole selection so
-		// users can Ctrl/Shift-select multiple files and add them all at once.
+		// users can Ctrl/Shift-select multiple files (and folders) and add them all.
 		const selectedResources = (resources && resources.length > 0)
 			? resources
 			: (resource ? [resource] : []);
@@ -1453,12 +1462,37 @@ export function registerImagePreviewCommands(
 					logCommand('browseAndAddToCollection', 'error', 'No image files in selection');
 					return;
 				}
-				const { added, skipped } = await addUrisToCollection(activePreview, files);
+
+				// No preview open yet: open the first image as the preview, then add
+				// the rest to its collection. This removes the chicken-and-egg of
+				// having to open an image manually before the menu does anything.
+				let activePreview = previewManager.activePreview;
+				let filesToAdd = files;
+				if (!activePreview) {
+					const [first, ...rest] = files;
+					activePreview = await openPreviewForResource(first);
+					if (!activePreview) {
+						vscode.window.showErrorMessage('Failed to open the image in TIFF Visualizer.');
+						logCommand('browseAndAddToCollection', 'error', 'Failed to open initial preview');
+						return;
+					}
+					filesToAdd = rest;
+				}
+
+				const { added, skipped } = await addUrisToCollection(activePreview, filesToAdd);
 				logCommand('browseAndAddToCollection', 'success', `explorer: added ${added}, skipped ${skipped}`);
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to add images to collection: ${error}`);
 				logCommand('browseAndAddToCollection', 'error', String(error));
 			}
+			return;
+		}
+
+		// Command-palette invocation needs an already-open image to anchor the picker.
+		const activePreview = previewManager.activePreview;
+		if (!activePreview) {
+			vscode.window.showErrorMessage('No active TIFF Visualizer preview found. Please open an image first.');
+			logCommand('browseAndAddToCollection', 'error', 'No active preview');
 			return;
 		}
 

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as fs from 'fs';
 import { Utils } from 'vscode-uri';
 import { BinarySizeStatusBarEntry } from '../binarySizeStatusBarEntry';
 import { SizeStatusBarEntry } from './sizeStatusBarEntry';
@@ -95,12 +94,44 @@ function segmentToRegex(segment: string): RegExp {
 const MAX_GLOB_RESULTS = 2000;
 
 /**
- * Async resolveWildcardDirs — same logic as the sync version but uses fs.promises.
+ * Path helpers that resolve typed path strings against an "anchor" URI — the
+ * currently open image. All filesystem access goes through `vscode.workspace.fs`
+ * rather than Node's `fs`, and child URIs inherit the anchor's scheme and
+ * authority. This is what makes wildcard scanning work over Remote-SSH, dev
+ * containers, and VS Code Web, instead of accidentally hitting the local disk.
+ */
+function pathModuleFor(anchor: vscode.Uri): path.PlatformPath {
+	// Local files follow the host OS path rules; everything else (remote, virtual) is POSIX.
+	return anchor.scheme === 'file' ? path : path.posix;
+}
+
+/** Builds a URI for an absolute path string, inheriting scheme/authority from the anchor. */
+function pathToUri(p: string, anchor: vscode.Uri): vscode.Uri {
+	if (anchor.scheme === 'file') {
+		return vscode.Uri.file(p);
+	}
+	return anchor.with({ path: p.replace(/\\/g, '/'), query: '', fragment: '' });
+}
+
+/** stat() a path string via the VS Code filesystem API; undefined if it does not exist. */
+async function statPath(p: string, anchor: vscode.Uri): Promise<vscode.FileStat | undefined> {
+	try { return await vscode.workspace.fs.stat(pathToUri(p, anchor)); } catch { return undefined; }
+}
+
+/** readDirectory() a path string via the VS Code filesystem API; empty if unreadable. */
+async function readDirPath(p: string, anchor: vscode.Uri): Promise<[string, vscode.FileType][]> {
+	try { return await vscode.workspace.fs.readDirectory(pathToUri(p, anchor)); } catch { return []; }
+}
+
+/**
+ * Expand the directory portion of a path (which may itself contain wildcards)
+ * into the list of concrete directories it matches.
  * Accepts an isCancelled callback so in-flight scans abort as soon as the QuickPick closes.
  */
-async function resolveWildcardDirsAsync(dirPath: string, isCancelled: () => boolean): Promise<string[]> {
+async function resolveWildcardDirsAsync(dirPath: string, anchor: vscode.Uri, isCancelled: () => boolean): Promise<string[]> {
+	const pp = pathModuleFor(anchor);
 	if (!dirPath.includes('*') && !dirPath.includes('?')) {
-		try { await fs.promises.access(dirPath); return [dirPath]; } catch { return []; }
+		return (await statPath(dirPath, anchor)) ? [dirPath] : [];
 	}
 	const segments = dirPath.split(/[/\\]/);
 	const baseSegs: string[] = [];
@@ -109,7 +140,7 @@ async function resolveWildcardDirsAsync(dirPath: string, isCancelled: () => bool
 		baseSegs.push(seg);
 	}
 	const wildcardSegs = segments.slice(baseSegs.length);
-	const baseDir = baseSegs.join(path.sep) || path.sep;
+	const baseDir = baseSegs.join(pp.sep) || pp.sep;
 
 	async function walkDirs(dir: string, segs: string[]): Promise<string[]> {
 		if (isCancelled()) return [];
@@ -117,22 +148,18 @@ async function resolveWildcardDirsAsync(dirPath: string, isCancelled: () => bool
 		const [head, ...rest] = segs;
 		if (!head) return walkDirs(dir, rest);
 		if (!/[*?]/.test(head)) {
-			const next = path.join(dir, head);
-			try { await fs.promises.access(next); return walkDirs(next, rest); } catch { return []; }
+			const next = pp.join(dir, head);
+			return (await statPath(next, anchor)) ? walkDirs(next, rest) : [];
 		}
 		const regex = segmentToRegex(head);
-		let names: string[];
-		try { names = await fs.promises.readdir(dir); } catch { return []; }
+		const entries = await readDirPath(dir, anchor);
 		const out: string[] = [];
-		for (const name of names) {
+		for (const [name, fileType] of entries) {
 			if (isCancelled()) return out;
 			if (!regex.test(name)) continue;
-			const fullPath = path.join(dir, name);
-			try {
-				if ((await fs.promises.stat(fullPath)).isDirectory()) {
-					out.push(...await walkDirs(fullPath, rest));
-				}
-			} catch { /* skip inaccessible */ }
+			if (fileType & vscode.FileType.Directory) {
+				out.push(...await walkDirs(pp.join(dir, name), rest));
+			}
 		}
 		return out;
 	}
@@ -141,77 +168,73 @@ async function resolveWildcardDirsAsync(dirPath: string, isCancelled: () => bool
 }
 
 /**
- * Async glob expansion — uses fs.promises and supports cancellation + a hard result cap.
- * Mutates the shared `results` array so the cap is enforced across recursive calls.
+ * Async glob expansion via the VS Code filesystem API, with cancellation and a
+ * hard result cap. Mutates the shared `results` array so the cap is enforced
+ * across recursive calls.
  */
 async function expandGlobSegmentsAsync(
 	baseDir: string,
 	segments: string[],
+	anchor: vscode.Uri,
 	results: vscode.Uri[],
 	isCancelled: () => boolean,
 ): Promise<void> {
 	if (isCancelled() || results.length >= MAX_GLOB_RESULTS || segments.length === 0) return;
 
+	const pp = pathModuleFor(anchor);
 	const [head, ...tail] = segments;
 	const isLast = tail.length === 0;
 
 	if (!head.includes('*') && !head.includes('?')) {
-		const fullPath = path.join(baseDir, head);
+		const fullPath = pp.join(baseDir, head);
 		if (isLast) {
-			try {
-				const st = await fs.promises.stat(fullPath);
-				if (st.isFile()) {
-					const ext = head.split('.').pop()?.toLowerCase() ?? '';
-					if (IMAGE_EXTENSIONS.includes(ext)) results.push(vscode.Uri.file(fullPath));
-				}
-			} catch { /* not found */ }
+			const st = await statPath(fullPath, anchor);
+			if (st && (st.type & vscode.FileType.File)) {
+				const uri = pathToUri(fullPath, anchor);
+				if (isImageUri(uri)) results.push(uri);
+			}
 		} else {
-			await expandGlobSegmentsAsync(fullPath, tail, results, isCancelled);
+			await expandGlobSegmentsAsync(fullPath, tail, anchor, results, isCancelled);
 		}
 		return;
 	}
 
 	const regex = segmentToRegex(head);
-	try {
-		const entries = await fs.promises.readdir(baseDir);
-		for (const entry of entries) {
-			if (isCancelled() || results.length >= MAX_GLOB_RESULTS) return;
-			if (!regex.test(entry)) continue;
-			const fullPath = path.join(baseDir, entry);
-			try {
-				const stat = await fs.promises.stat(fullPath);
-				if (isLast) {
-					if (stat.isFile()) {
-						const ext = entry.split('.').pop()?.toLowerCase() ?? '';
-						if (IMAGE_EXTENSIONS.includes(ext)) results.push(vscode.Uri.file(fullPath));
-					}
-				} else {
-					if (stat.isDirectory()) {
-						await expandGlobSegmentsAsync(fullPath, tail, results, isCancelled);
-					}
-				}
-			} catch { /* skip inaccessible entries */ }
+	const entries = await readDirPath(baseDir, anchor);
+	for (const [entry, fileType] of entries) {
+		if (isCancelled() || results.length >= MAX_GLOB_RESULTS) return;
+		if (!regex.test(entry)) continue;
+		const fullPath = pp.join(baseDir, entry);
+		if (isLast) {
+			if (fileType & vscode.FileType.File) {
+				const uri = pathToUri(fullPath, anchor);
+				if (isImageUri(uri)) results.push(uri);
+			}
+		} else {
+			if (fileType & vscode.FileType.Directory) {
+				await expandGlobSegmentsAsync(fullPath, tail, anchor, results, isCancelled);
+			}
 		}
-	} catch { /* unreadable directory */ }
+	}
 }
 
-async function expandGlobPatternAsync(pattern: string, isCancelled: () => boolean): Promise<vscode.Uri[]> {
+async function expandGlobPatternAsync(pattern: string, anchor: vscode.Uri, isCancelled: () => boolean): Promise<vscode.Uri[]> {
+	const pp = pathModuleFor(anchor);
 	if (!pattern.includes('*') && !pattern.includes('?')) {
-		try {
-			const st = await fs.promises.stat(pattern);
-			return st.isFile() ? [vscode.Uri.file(pattern)] : [];
-		} catch { return []; }
+		const st = await statPath(pattern, anchor);
+		return st && (st.type & vscode.FileType.File) ? [pathToUri(pattern, anchor)] : [];
 	}
 
 	const firstWild = pattern.search(/[*?]/);
 	const beforeWild = pattern.substring(0, firstWild);
-	const baseDir = path.dirname(beforeWild.endsWith(path.sep) ? beforeWild + '_' : beforeWild);
+	const endsWithSep = beforeWild.endsWith('/') || beforeWild.endsWith('\\');
+	const baseDir = pp.dirname(endsWithSep ? beforeWild + '_' : beforeWild);
 	const remainder = pattern.substring(baseDir.length + 1);
 	const segments = remainder.split(/[/\\]/);
 
 	const results: vscode.Uri[] = [];
-	await expandGlobSegmentsAsync(baseDir, segments, results, isCancelled);
-	return results.sort((a, b) => a.fsPath.localeCompare(b.fsPath, undefined, { numeric: true }));
+	await expandGlobSegmentsAsync(baseDir, segments, anchor, results, isCancelled);
+	return results.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
 }
 
 /** Returns the final path segment of a URI (scheme-agnostic). */
@@ -1224,11 +1247,14 @@ export function registerImagePreviewCommands(
 	 * Show a QuickPick-based path picker with filesystem autocomplete.
 	 * Returns the final typed/selected pattern, or undefined if cancelled.
 	 */
-	async function pickPathWithAutocomplete(initialDir: string, existingCollection: readonly vscode.Uri[] = []): Promise<string | undefined> {
+	async function pickPathWithAutocomplete(anchor: vscode.Uri, existingCollection: readonly vscode.Uri[] = []): Promise<string | undefined> {
+		const pp = pathModuleFor(anchor);
+		const sep = pp.sep;
+		const initialDir = pp.dirname(anchor.scheme === 'file' ? anchor.fsPath : anchor.path);
 		return new Promise<string | undefined>((resolve) => {
 			const qp = vscode.window.createQuickPick();
 			qp.placeholder = 'Type a path or wildcard pattern (e.g. *.tiff)';
-			qp.value = initialDir + path.sep;
+			qp.value = initialDir + sep;
 			qp.matchOnDescription = false;
 			qp.matchOnDetail = false;
 
@@ -1259,15 +1285,15 @@ export function registerImagePreviewCommands(
 
 				if (typed) {
 					try {
-						const trailingSlash = typed.endsWith(path.sep) || typed.endsWith('/');
+						const trailingSlash = typed.endsWith('/') || typed.endsWith('\\');
 						let dirToList: string;
 						let prefix: string;
 						if (trailingSlash) {
-							dirToList = typed.replace(/[/\\]+$/, '') || path.sep;
+							dirToList = typed.replace(/[/\\]+$/, '') || sep;
 							prefix = '';
 						} else {
-							dirToList = path.dirname(typed);
-							prefix = path.basename(typed).toLowerCase();
+							dirToList = pp.dirname(typed);
+							prefix = pp.basename(typed).toLowerCase();
 						}
 
 						const prefixHasWild = /[*?]/.test(prefix);
@@ -1275,32 +1301,25 @@ export function registerImagePreviewCommands(
 						const matchesPrefix = (name: string) =>
 							prefixHasWild ? prefixRegex!.test(name) : name.startsWith(prefix);
 
-						const imageExts = new Set(IMAGE_EXTENSIONS);
-						const dirsToList = await resolveWildcardDirsAsync(dirToList, isCancelled);
+						const dirsToList = await resolveWildcardDirsAsync(dirToList, anchor, isCancelled);
 
 						if (searchVersion !== version) return;
 
 						for (const dir of dirsToList) {
 							if (searchVersion !== version) return;
 
-							let entries: fs.Dirent[];
-							try {
-								entries = await fs.promises.readdir(dir, { withFileTypes: true });
-							} catch { continue; }
+							const entries = await readDirPath(dir, anchor);
 
 							if (searchVersion !== version) return;
 
-							for (const entry of entries) {
-								const name = entry.name;
+							for (const [name, fileType] of entries) {
 								if (!matchesPrefix(name.toLowerCase())) continue;
 
-								const fullPath = path.join(dir, name);
-								let isDir = entry.isDirectory();
-								if (!isDir && entry.isSymbolicLink()) {
-									try {
-										const st = await fs.promises.stat(fullPath);
-										isDir = st.isDirectory();
-									} catch { isDir = false; }
+								const fullPath = pp.join(dir, name);
+								let isDir = (fileType & vscode.FileType.Directory) !== 0;
+								if (!isDir && (fileType & vscode.FileType.SymbolicLink)) {
+									const st = await statPath(fullPath, anchor);
+									isDir = !!st && (st.type & vscode.FileType.Directory) !== 0;
 								}
 
 								if (isDir) {
@@ -1311,16 +1330,13 @@ export function registerImagePreviewCommands(
 										alwaysShow: true,
 									} as vscode.QuickPickItem & { _dirPath?: string });
 									(contentItems[contentItems.length - 1] as any)._dirPath = fullPath;
-								} else {
-									const ext = name.split('.').pop()?.toLowerCase() ?? '';
-									if (imageExts.has(ext)) {
-										contentItems.push({
-											label: '$(file-media) ' + name,
-											description: fullPath,
-											alwaysShow: true,
-										} as vscode.QuickPickItem & { _filePath?: string });
-										(contentItems[contentItems.length - 1] as any)._filePath = fullPath;
-									}
+								} else if (isImageUri(pathToUri(fullPath, anchor))) {
+									contentItems.push({
+										label: '$(file-media) ' + name,
+										description: fullPath,
+										alwaysShow: true,
+									} as vscode.QuickPickItem & { _filePath?: string });
+									(contentItems[contentItems.length - 1] as any)._filePath = fullPath;
 								}
 							}
 						}
@@ -1332,7 +1348,8 @@ export function registerImagePreviewCommands(
 				// Detect if the typed path is a plain directory (no wildcards)
 				let isDirectoryPath = false;
 				if (typed && !typed.includes('*') && !typed.includes('?')) {
-					try { isDirectoryPath = (await fs.promises.stat(typed.replace(/[/\\]+$/, '') || path.sep)).isDirectory(); } catch { /* ignore */ }
+					const st = await statPath(typed.replace(/[/\\]+$/, '') || sep, anchor);
+					isDirectoryPath = !!st && (st.type & vscode.FileType.Directory) !== 0;
 					if (searchVersion !== version) return;
 				}
 
@@ -1345,7 +1362,7 @@ export function registerImagePreviewCommands(
 					};
 					(finalUseItem as any)._useRaw = false; // not selectable as a pattern
 				} else {
-					const files = await expandGlobPatternAsync(typed, isCancelled);
+					const files = await expandGlobPatternAsync(typed, anchor, isCancelled);
 					if (searchVersion !== version) return;
 					const existingSet = new Set(existingCollection.map(u => u.toString()));
 					const newCount = files.filter(u => !existingSet.has(u.toString())).length;
@@ -1388,7 +1405,7 @@ export function registerImagePreviewCommands(
 					// Warning item (folder path) — ignore, let user keep typing
 				} else if (selected._dirPath) {
 					// Navigate into directory
-					qp.value = selected._dirPath + path.sep;
+					qp.value = selected._dirPath + sep;
 					updateSuggestions(qp.value);
 				} else if (selected._filePath) {
 					resolve(selected._filePath);
@@ -1445,11 +1462,10 @@ export function registerImagePreviewCommands(
 			return;
 		}
 
-		const currentDir = path.dirname(activePreview.resource.fsPath);
-		const pattern = await pickPathWithAutocomplete(currentDir, activePreview.imageCollection);
+		const pattern = await pickPathWithAutocomplete(activePreview.resource, activePreview.imageCollection);
 		if (!pattern) { return; }
 
-		const filesToAdd = await expandGlobPatternAsync(pattern, () => false);
+		const filesToAdd = await expandGlobPatternAsync(pattern, activePreview.resource, () => false);
 		if (filesToAdd.length === 0) {
 			vscode.window.showWarningMessage(`No image files found matching: ${pattern}`);
 			logCommand('browseAndAddToCollection', 'error', `No files matching: ${pattern}`);

--- a/src/imagePreview/commands.ts
+++ b/src/imagePreview/commands.ts
@@ -289,13 +289,20 @@ async function collectImageFiles(uris: vscode.Uri[]): Promise<vscode.Uri[]> {
  * Shared by the Explorer context-menu path and the wildcard pattern picker.
  */
 async function addUrisToCollection(
-	activePreview: { addToImageCollection(uri: vscode.Uri): Promise<boolean> },
+	activePreview: {
+		addToImageCollection(uri: vscode.Uri): Promise<boolean>;
+		ensureLocalResourceRoots(uris: vscode.Uri[]): void;
+	},
 	uris: vscode.Uri[],
 ): Promise<{ added: number; skipped: number }> {
 	const result = { added: 0, skipped: 0 };
 	if (uris.length === 0) {
 		return result;
 	}
+
+	// Register all folders in one shot so the webview reloads at most once
+	// (ideally zero times for in-workspace images) instead of per file.
+	activePreview.ensureLocalResourceRoots(uris);
 
 	let firstAdded: vscode.Uri | undefined;
 	await vscode.window.withProgress(

--- a/src/imagePreview/imagePreview.ts
+++ b/src/imagePreview/imagePreview.ts
@@ -413,12 +413,19 @@ export class ImagePreview extends MediaPreview {
 	 */
 	public ensureLocalResourceRoots(uris: vscode.Uri[]): void {
 		const currentRoots = this._webviewEditor.webview.options.localResourceRoots ?? [];
-		const have = new Set(currentRoots.map(r => r.toString()));
 		const toAdd: vscode.Uri[] = [];
+		const isCovered = (dir: vscode.Uri): boolean => {
+			return [...currentRoots, ...toAdd].some(root => {
+				if (root.scheme !== dir.scheme || root.authority !== dir.authority) {
+					return false;
+				}
+				const rootPath = root.path.endsWith('/') ? root.path : `${root.path}/`;
+				return dir.path === root.path || dir.path.startsWith(rootPath);
+			});
+		};
 		for (const uri of uris) {
 			const dir = Utils.dirname(uri);
-			const key = dir.toString();
-			if (!have.has(key) && !toAdd.some(d => d.toString() === key)) {
+			if (!isCovered(dir)) {
 				toAdd.push(dir);
 			}
 		}
@@ -800,4 +807,4 @@ export class ImagePreview extends MediaPreview {
 	private extensionResource(...parts: string[]) {
 		return vscode.Uri.joinPath(this.extensionRoot, ...parts);
 	}
-} 
+}

--- a/src/imagePreview/imagePreview.ts
+++ b/src/imagePreview/imagePreview.ts
@@ -405,6 +405,31 @@ export class ImagePreview extends MediaPreview {
 		return this._imageCollection;
 	}
 
+	/**
+	 * Ensure the webview's localResourceRoots cover the directories of the given
+	 * URIs, reassigning webview.options at most once. Reassigning options reloads
+	 * the webview, so callers should pass a whole batch to avoid repeated reloads,
+	 * and this is a no-op when every folder is already covered.
+	 */
+	public ensureLocalResourceRoots(uris: vscode.Uri[]): void {
+		const currentRoots = this._webviewEditor.webview.options.localResourceRoots ?? [];
+		const have = new Set(currentRoots.map(r => r.toString()));
+		const toAdd: vscode.Uri[] = [];
+		for (const uri of uris) {
+			const dir = Utils.dirname(uri);
+			const key = dir.toString();
+			if (!have.has(key) && !toAdd.some(d => d.toString() === key)) {
+				toAdd.push(dir);
+			}
+		}
+		if (toAdd.length > 0) {
+			this._webviewEditor.webview.options = {
+				...this._webviewEditor.webview.options,
+				localResourceRoots: [...currentRoots, ...toAdd],
+			};
+		}
+	}
+
 	/** Returns true if the image was added, false if it was already in the collection. */
 	public async addToImageCollection(uri: vscode.Uri): Promise<boolean> {
 		if (this._imageCollection.some(img => img.toString() === uri.toString())) {
@@ -413,16 +438,10 @@ export class ImagePreview extends MediaPreview {
 
 		this._imageCollection.push(uri);
 
-		// Expand localResourceRoots to include the new image's directory so
-		// the webview fetch() can access files outside the initial file's folder.
-		const newDir = Utils.dirname(uri);
-		const currentRoots = this._webviewEditor.webview.options.localResourceRoots ?? [];
-		if (!currentRoots.some(r => r.toString() === newDir.toString())) {
-			this._webviewEditor.webview.options = {
-				...this._webviewEditor.webview.options,
-				localResourceRoots: [...currentRoots, newDir],
-			};
-		}
+		// Make sure the webview can fetch this image's folder. Reassigning
+		// webview.options reloads the webview, so this is a no-op when the folder
+		// is already covered (e.g. it's inside the workspace).
+		this.ensureLocalResourceRoots([uri]);
 
 		// Start preloading the image data (async, don't wait)
 		this.preloadImageData(uri);

--- a/src/imagePreview/types.ts
+++ b/src/imagePreview/types.ts
@@ -36,6 +36,7 @@ export interface IImagePreview {
 	updateStatusBar(): void;
 	readonly imageCollection: readonly vscode.Uri[];
 	addToImageCollection(uri: vscode.Uri): Promise<boolean>;
+	ensureLocalResourceRoots(uris: vscode.Uri[]): void;
 	pastePosition(): void;
 	jumpToCollectionIndex(index: number): void;
 	removeCurrentFromCollection(): void;

--- a/src/mediaPreview.ts
+++ b/src/mediaPreview.ts
@@ -29,6 +29,10 @@ export abstract class MediaPreview extends Disposable {
 			localResourceRoots: [
 				Utils.dirname(_resource),
 				extensionRoot,
+				// Include workspace folders up front so adding images from the
+				// workspace to a collection doesn't require reassigning
+				// webview.options later (which reloads the webview).
+				...(vscode.workspace.workspaceFolders?.map(f => f.uri) ?? []),
 			]
 		};
 


### PR DESCRIPTION

- Fix collection creation on remote computers and allow selecting multiple images and adding them to collection. Thanks @130040167 in #2
- expand collection creation to support Explorer selections, folders, wildcards, Remote-SSH, and adding without an open preview
- keep rapid collection navigation responsive by cancelling superseded loads and decoding supported formats off the UI thread
- initialize TIFF WASM reliably inside the decode worker, with GeoTIFF worker fallback and per-phase performance tracing
- prevent stale renders, overlapping images, and unnecessary reloads when adding collection entries
